### PR TITLE
fix: invalid reflection paths in sample app build script

### DIFF
--- a/apps/maps-sample/build.gradle.kts
+++ b/apps/maps-sample/build.gradle.kts
@@ -13,8 +13,8 @@ plugins {
 var googlemapsDependency = "com.openmobilehub.android.maps:plugin-googlemaps:2.0.0-beta"
 var openstreetmapDependency = "com.openmobilehub.android.maps:plugin-openstreetmap:2.0.0-beta"
 
-var googlemapsPath = "com.openmobilehub.android.maps.plugin.googlemaps.presentation.OmhAuthFactoryImpl"
-var openstreetmapPath = "com.openmobilehub.android.maps.plugin.openstreetmap.presentation.OmhAuthFactoryImpl"
+var googlemapsPath = "com.openmobilehub.android.maps.plugin.googlemaps.presentation.OmhMapFactoryImpl"
+var openstreetmapPath = "com.openmobilehub.android.maps.plugin.openstreetmap.presentation.OmhMapFactoryImpl"
 
 omhConfig {
     bundle("singleBuild") {


### PR DESCRIPTION
Fix for invalid reflection paths in `maps-sample` gradle script