### PR TITLE
fix: move GitHub PR template so that it is used by default

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,12 @@
 ## Summary
 
 ## Demo
+
 ![Demo Preview]()
 
 ## Checklist:
+
 - [ ] Documentation is up to date to reflect these changes
 - [ ] Created Unit tests
 
-Closes: [FUTD-{ticket_id}](https://callstackio.atlassian.net/browse/FUTD-{ticket_id})
+Closes: [OMHD-{ticket_id}](https://callstackio.atlassian.net/browse/OMHD-{ticket_id})


### PR DESCRIPTION
Currently, the PR template requires specifying `?template=...` in PR creation URL, while we want it to be applied by default.