### PR TITLE
CI: documentation automated publishing pipeline & action updates

### DIFF
--- a/.github/workflows/build_and_publish_to_maven_local.yml
+++ b/.github/workflows/build_and_publish_to_maven_local.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
@@ -39,7 +39,7 @@ jobs:
 
       - name: Restore MavenLocal Cache
         if: ${{ inputs.input-cache-prefix != '' }}
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ inputs.input-cache-prefix }}-${{ github.run_id }}
@@ -51,7 +51,7 @@ jobs:
         run: ./gradlew ${{ inputs.gradle-command }}
 
       - name: Cache MavenLocal
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ inputs.output-cache-prefix }}-${{ github.run_id }}

--- a/.github/workflows/build_and_publish_to_maven_remotely.yml
+++ b/.github/workflows/build_and_publish_to_maven_remotely.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
@@ -45,7 +45,7 @@ jobs:
         run: echo useMavenLocal=true >> local.properties
 
       - name: Restore Cache MavenLocal
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: mavenLocal-core-and-plugins-${{ github.run_id }}
@@ -58,7 +58,7 @@ jobs:
     needs: maps-plugins
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -74,7 +74,7 @@ jobs:
         run: echo useMavenLocal=true >> local.properties
 
       - name: Restore Cache MavenLocal
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: mavenLocal-core-and-plugins-${{ github.run_id }}

--- a/.github/workflows/on_push_workflow.yml
+++ b/.github/workflows/on_push_workflow.yml
@@ -5,7 +5,7 @@ name: Android CD
 
 on:
   push:
-    branches: [ci/docs-pipeline, main]
+    branches: [main]
 
 # GITHUB_TOKEN needs to be granted the permissions required to make a Pages deployment
 permissions:
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
@@ -64,7 +64,7 @@ jobs:
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
 
       - name: Setup secrets
         run: bash ./.github/scripts/setup_secrets.sh "${{ secrets.MAPBOX_SECRET_TOKEN }}" "${{ secrets.GOOGLE_MAPS_API_KEY }}" "${{ secrets.MAPBOX_PUBLIC_TOKEN }}"
@@ -73,7 +73,7 @@ jobs:
         run: echo useMavenLocal=true >> local.properties
 
       - name: Restore Cache MavenLocal
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: mavenLocal-core-and-plugins-${{ github.run_id }}
@@ -82,7 +82,7 @@ jobs:
         run: ./gradlew buildDocs
 
       - name: Cache MavenLocal
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ inputs.output-cache-prefix }}-${{ github.run_id }}

--- a/.github/workflows/publish_sample_app.yml
+++ b/.github/workflows/publish_sample_app.yml
@@ -21,18 +21,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: set up JDK 11
-        uses: actions/setup-java@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
         with:
-          java-version: 11
-          distribution: adopt
-          cache: gradle
+          cache-read-only: false
 
       - name: Restore Cache MavenLocal
         if: ${{ inputs.input-cache-prefix != '' }}
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ inputs.input-cache-prefix }}-${{ github.run_id }}


### PR DESCRIPTION
## Summary

This PR introduces an update to CI workflows bringing the following:
- updates to versions of packages that were safe to update (compatible): `checkout`, `cache` & `setup-pages`
- final transition from `setup-java` to `setup-gradle` in the last remaining workflow
- moved trigger for building & publishing documentation to GH Pages from `on_pull_request.yml` to `on_push_workflow.yml`

## Demo

[GH Pages private preview](https://bookish-eureka-1wmrl6z.pages.github.io/)

## Checklist:

- ~[] Documentation is up to date to reflect these changes~
- ~[] Created Unit tests~