### PR TITLE
docs: added Dokka file format rules to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,6 +135,8 @@ The following rules for writing markdown files apply:
 
 Each module's (except for `apps/maps-sample`) root `README.md` file will be included by default in Dokka documentation generation automatically and used in its listing page.
 
+The root `README.md` files for all projects have to comply with [Dokka file format rules](https://kotlinlang.org/docs/dokka-module-and-package-docs.html#file-format). In case of the OMH project, usually this means that you have to ensure that the first line of a project's top-level readme file is `# Module <project-directory-name>`, e.g. for `packages/plugin-googlemaps/README.md` the first line should be: `# Module plugin-googlemaps`.
+
 ### Custom documentation
 
 #### `README.md`


### PR DESCRIPTION
## Summary

This PR introduces additional information that may be helpful for contributors adding a new module regarding the format of the module's top-level `README.md` file with regards to the Dokka rules.

## Demo

N/A

## Checklist:

- [x] Documentation is up to date to reflect these changes
- ~[ ] Created Unit tests~
