### PR TITLE
OMHD-166: Polylines clicks fix

### DIFF
--- a/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/OmhMapImpl.kt
+++ b/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/OmhMapImpl.kt
@@ -85,9 +85,7 @@ internal class OmhMapImpl(
     private val polylineManager: PolylineManager = PolylineManager(mapView, scaleFactor),
     private val polygonManager: PolygonManager = PolygonManager(mapView, scaleFactor),
     private val logger: Logger = commonLogger,
-) : OmhMap,
-    IMapDragManagerDelegate,
-    IOmhInfoWindowMapViewDelegate {
+) : OmhMap, IMapDragManagerDelegate, IOmhInfoWindowMapViewDelegate {
     /**
      * This flag is used to prevent the onCameraMoveStarted listener from being called multiple times
      */
@@ -148,10 +146,8 @@ internal class OmhMapImpl(
     }
 
     override fun moveCamera(coordinate: OmhCoordinate, zoomLevel: Float) {
-        val cameraPosition = CameraOptions.Builder()
-            .zoom(zoomLevel.toDouble())
-            .center(CoordinateConverter.convertToPoint(coordinate))
-            .build()
+        val cameraPosition = CameraOptions.Builder().zoom(zoomLevel.toDouble())
+            .center(CoordinateConverter.convertToPoint(coordinate)).build()
 
         mapView.mapboxMap.setCamera(cameraPosition)
     }
@@ -255,10 +251,9 @@ internal class OmhMapImpl(
             mapView.context.resources.displayMetrics.heightPixels
         )
         val hitRadius =
-            (minScreenDimension.toDouble() * Constants.MAP_TOUCH_HIT_RADIUS_PERCENT_OF_SCREEN_DIM)
-                .coerceIn(
-                    Constants.MAP_TOUCH_HIT_RADIUS_MIN_PX..Constants.MAP_TOUCH_HIT_RADIUS_MAX_PX
-                )
+            (minScreenDimension.toDouble() * Constants.MAP_TOUCH_HIT_RADIUS_PERCENT_OF_SCREEN_DIM).coerceIn(
+                Constants.MAP_TOUCH_HIT_RADIUS_MIN_PX..Constants.MAP_TOUCH_HIT_RADIUS_MAX_PX
+            )
         val hits = mutableListOf<ITouchInteractable>()
 
         // try if an info window was hit
@@ -268,8 +263,7 @@ internal class OmhMapImpl(
             val markerPositionOnScreen = mapView.mapboxMap.pixelForCoordinate(
                 CoordinateConverter.convertToPoint(infoWindow.omhMarker.getPosition())
             ) + infoWindow.omhMarker.getHandleTopOffset()
-            val centerPositionOnScreen =
-                markerPositionOnScreen + infoWindow.getHandleCenterOffset()
+            val centerPositionOnScreen = markerPositionOnScreen + infoWindow.getHandleCenterOffset()
 
             val iwBoundingBox = BoundingBox2D(
                 centerPoint = centerPositionOnScreen,
@@ -359,15 +353,17 @@ internal class OmhMapImpl(
                     ) { eventConsumed ->
                         if (eventConsumed) mapTouchInteractionManager.resetDragState()
                     }
-                    Constants.POLYLINE_LAYER_TYPE -> polylineManager.maybeHandleClick(
-                        layerType,
+
+                    Constants.POLYLINE_LAYER_TYPE,
+                    Constants.POLYLINE_LAYER_TYPE_ALTERNATIVE -> polylineManager.maybeHandleClick(
                         layerId
                     )
 
-                    Constants.POLYGON_LAYER_TYPE -> polygonManager.maybeHandleClick(
-                        layerType,
-                        layerId
+                    Constants.POLYGON_LAYER_TYPE,
+                    Constants.POLYGON_LAYER_TYPE_ALTERNATIVE -> polygonManager.maybeHandleClick(
+                        layerId,
                     )
+
                     else -> false // Noop
                 }
             }
@@ -440,8 +436,7 @@ internal class OmhMapImpl(
 
     private fun setupMapViewUIControls() {
         // To have parity with Google Maps
-        val iconMargin =
-            ScreenUnitConverter.dpToPx(Constants.MAPBOX_ICON_MARGIN.toFloat(), context)
+        val iconMargin = ScreenUnitConverter.dpToPx(Constants.MAPBOX_ICON_MARGIN.toFloat(), context)
         mapView.compass.marginLeft = iconMargin
         mapView.compass.marginTop = iconMargin
         mapView.compass.position = Gravity.TOP or Gravity.START
@@ -463,12 +458,10 @@ internal class OmhMapImpl(
 
         val followPuckViewportState: FollowPuckViewportState =
             viewportPlugin.makeFollowPuckViewportState(
-                FollowPuckViewportStateOptions.Builder()
-                    .pitch(cameraState.pitch)
+                FollowPuckViewportStateOptions.Builder().pitch(cameraState.pitch)
                     .zoom(cameraState.zoom)
                     .bearing(FollowPuckViewportStateBearing.Constant(cameraState.bearing))
-                    .padding(cameraState.padding)
-                    .build()
+                    .padding(cameraState.padding).build()
             )
 
         viewportPlugin.transitionTo(followPuckViewportState)

--- a/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/managers/PolygonManager.kt
+++ b/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/managers/PolygonManager.kt
@@ -61,13 +61,11 @@ class PolygonManager(
         return layerId.replace(POLYGON_OUTLINE_LAYER_PREFIX, "")
     }
 
-    fun maybeHandleClick(type: String, layerId: String): Boolean {
-        if (type === POLYGON_LAYER_TYPE) {
-            val omhPolygon = polygons[getPolygonId(layerId)]
-            if (omhPolygon !== null && omhPolygon.getClickable()) {
-                clickListener?.onPolygonClick(omhPolygon)?.let { evenConsumed ->
-                    return evenConsumed
-                }
+    fun maybeHandleClick(layerId: String): Boolean {
+        val omhPolygon = polygons[getPolygonId(layerId)]
+        if (omhPolygon !== null && omhPolygon.getClickable()) {
+            clickListener?.onPolygonClick(omhPolygon)?.let { evenConsumed ->
+                return evenConsumed
             }
         }
 
@@ -158,6 +156,5 @@ class PolygonManager(
     companion object {
         private const val POLYGON_LAYER_PREFIX = "polygon-"
         private const val POLYGON_OUTLINE_LAYER_PREFIX = "outline-"
-        private const val POLYGON_LAYER_TYPE = "Polygon"
     }
 }

--- a/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/managers/PolylineManager.kt
+++ b/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/managers/PolylineManager.kt
@@ -61,13 +61,11 @@ class PolylineManager(
         )
     }
 
-    fun maybeHandleClick(type: String, layerId: String): Boolean {
-        if (type === Constants.POLYLINE_LAYER_TYPE) {
-            val omhPolyline = polylines[layerId]
-            if (omhPolyline !== null && omhPolyline.getClickable()) {
-                clickListener?.onPolylineClick(omhPolyline)?.let { eventConsumed ->
-                    return eventConsumed
-                }
+    fun maybeHandleClick(layerId: String): Boolean {
+        val omhPolyline = polylines[layerId]
+        if (omhPolyline !== null && omhPolyline.getClickable()) {
+            clickListener?.onPolylineClick(omhPolyline)?.let { eventConsumed ->
+                return eventConsumed
             }
         }
         return false

--- a/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/utils/Constants.kt
+++ b/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/utils/Constants.kt
@@ -71,6 +71,12 @@ internal object Constants {
 
     // Map Elements
     const val POLYLINE_LAYER_TYPE = "LineString"
+
+    /** Depending on the shape, Mapbox SDK can convert LineString to MultiLineString */
+    const val POLYLINE_LAYER_TYPE_ALTERNATIVE = "MultiLineString"
     const val POLYGON_LAYER_TYPE = "Polygon"
+
+    /** Depending on the shape, Mapbox SDK can convert Polygon to MultiPolygon   */
+    const val POLYGON_LAYER_TYPE_ALTERNATIVE = "MultiPolygon"
     const val MARKER_OR_INFO_WINDOW_LAYER_TYPE = "Point"
 }

--- a/packages/plugin-mapbox/src/test/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/OmhMapImplTest.kt
+++ b/packages/plugin-mapbox/src/test/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/OmhMapImplTest.kt
@@ -883,7 +883,7 @@ class OmhMapImplTest {
     }
 
     @Test
-    fun `polylineManager_maybeHandleClick is called when polyline is clicked`() {
+    fun `polylineManager_maybeHandleClick is called when polyline with LineString layer type is clicked`() {
         // Arrange
         val listener = mockk<OmhOnPolylineClickListener>(relaxed = true)
 
@@ -908,7 +908,36 @@ class OmhMapImplTest {
         onMapClickListenerSlot.captured.onMapClick(Point.fromLngLat(0.0, 0.0))
 
         // Assert
-        verify { polylineManager.maybeHandleClick(type, layerId) }
+        verify { polylineManager.maybeHandleClick(layerId) }
+    }
+
+    @Test
+    fun `polylineManager_maybeHandleClick is called when polyline with MultiLineString layer type is clicked`() {
+        // Arrange
+        val listener = mockk<OmhOnPolylineClickListener>(relaxed = true)
+
+        val layerId = "polyline-$DEFAULT_UUID"
+        val type = "MultiLineString"
+
+        mockQueryRenderedFeatures(layerId, type)
+        mockPixelForCoordinate()
+
+        setupLoadStyleCallback()
+
+        val onMapClickListenerSlot = slot<OnMapClickListener>()
+        every { map.gestures.addOnMapClickListener(capture(onMapClickListenerSlot)) } just runs
+
+        mockQueryRenderedFeatures("polyline-$DEFAULT_UUID", Constants.POLYLINE_LAYER_TYPE)
+        mockPixelForCoordinate()
+
+        // Act
+        omhMapImpl = createOmhMapImplInstance()
+
+        omhMapImpl.setOnPolylineClickListener(listener)
+        onMapClickListenerSlot.captured.onMapClick(Point.fromLngLat(0.0, 0.0))
+
+        // Assert
+        verify { polylineManager.maybeHandleClick(layerId) }
     }
 
     @Test
@@ -957,7 +986,7 @@ class OmhMapImplTest {
     }
 
     @Test
-    fun `polygonManager_maybeHandleClick is called when polygon is clicked`() {
+    fun `polygonManager_maybeHandleClick is called when polygon with Polygon layer type is clicked`() {
         // Arrange
         val listener = mockk<OmhOnPolygonClickListener>(relaxed = true)
 
@@ -978,7 +1007,32 @@ class OmhMapImplTest {
         onMapClickListenerSlot.captured.onMapClick(Point.fromLngLat(0.0, 0.0))
 
         // Assert
-        verify { polygonManager.maybeHandleClick(type, layerId) }
+        verify { polygonManager.maybeHandleClick(layerId) }
+    }
+
+    @Test
+    fun `polygonManager_maybeHandleClick is called when polygon with MultiPolygon layer type is clicked`() {
+        // Arrange
+        val listener = mockk<OmhOnPolygonClickListener>(relaxed = true)
+
+        val layerId = "polygon-$DEFAULT_UUID"
+        val type = "MultiPolygon"
+
+        mockQueryRenderedFeatures(layerId, type)
+        mockPixelForCoordinate()
+
+        val onMapClickListenerSlot = slot<OnMapClickListener>()
+        every { map.gestures.addOnMapClickListener(capture(onMapClickListenerSlot)) } just runs
+
+        setupLoadStyleCallback()
+
+        // Act
+        omhMapImpl = createOmhMapImplInstance()
+        omhMapImpl.setOnPolygonClickListener(listener)
+        onMapClickListenerSlot.captured.onMapClick(Point.fromLngLat(0.0, 0.0))
+
+        // Assert
+        verify { polygonManager.maybeHandleClick(layerId) }
     }
 
     companion object {

--- a/packages/plugin-mapbox/src/test/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/managers/PolygonManagerTest.kt
+++ b/packages/plugin-mapbox/src/test/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/managers/PolygonManagerTest.kt
@@ -44,19 +44,6 @@ class PolygonManagerTest {
     }
 
     @Test
-    fun `maybeHandleClick does nothing if type does not match Polygon type`() {
-        // Arrange
-        val clickHandler = mockk<OmhOnPolygonClickListener>(relaxed = true)
-        polygonManager.clickListener = clickHandler
-
-        // Act
-        polygonManager.maybeHandleClick("Polyline", "id")
-
-        // Assert
-        verify(exactly = 0) { clickHandler.onPolygonClick(any<OmhPolygon>()) }
-    }
-
-    @Test
     fun `maybeHandleClick does nothing if Polygon with given id does not exist`() {
         // Arrange
         // We have empty polygons map
@@ -64,7 +51,7 @@ class PolygonManagerTest {
         polygonManager.clickListener = clickHandler
 
         // Act
-        polygonManager.maybeHandleClick("Polygon", "id")
+        polygonManager.maybeHandleClick("id")
 
         // Assert
         verify(exactly = 0) { clickHandler.onPolygonClick(any<OmhPolygon>()) }
@@ -83,7 +70,7 @@ class PolygonManagerTest {
 
         // Act
         polygonManager.addPolygon(polygonOptions, null)
-        polygonManager.maybeHandleClick("Polygon", "polygon-$DEFAULT_UUID")
+        polygonManager.maybeHandleClick("polygon-$DEFAULT_UUID")
 
         // Assert
         verify(exactly = 0) { clickHandler.onPolygonClick(any<OmhPolygon>()) }
@@ -102,7 +89,7 @@ class PolygonManagerTest {
 
         // Act
         polygonManager.addPolygon(polygonOptions, null)
-        polygonManager.maybeHandleClick("Polygon", "polygon-$DEFAULT_UUID")
+        polygonManager.maybeHandleClick("polygon-$DEFAULT_UUID")
 
         // Assert
         verify(exactly = 1) { clickHandler.onPolygonClick(any<OmhPolygon>()) }

--- a/packages/plugin-mapbox/src/test/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/managers/PolylineManagerTest.kt
+++ b/packages/plugin-mapbox/src/test/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/managers/PolylineManagerTest.kt
@@ -44,19 +44,6 @@ class PolylineManagerTest {
     }
 
     @Test
-    fun `maybeHandleClick does nothing if type does not match LineString type`() {
-        // Arrange
-        val clickHandler = mockk<OmhOnPolylineClickListener>(relaxed = true)
-        polylineManager.clickListener = clickHandler
-
-        // Act
-        polylineManager.maybeHandleClick("Polygon", "id")
-
-        // Assert
-        verify(exactly = 0) { clickHandler.onPolylineClick(any<OmhPolyline>()) }
-    }
-
-    @Test
     fun `maybeHandleClick does nothing if LineString with given id does not exist`() {
         // Arrange
         // We have empty polylines map
@@ -64,7 +51,7 @@ class PolylineManagerTest {
         polylineManager.clickListener = clickHandler
 
         // Act
-        polylineManager.maybeHandleClick("LineString", "id")
+        polylineManager.maybeHandleClick("id")
 
         // Assert
         verify(exactly = 0) { clickHandler.onPolylineClick(any<OmhPolyline>()) }
@@ -83,7 +70,7 @@ class PolylineManagerTest {
 
         // Act
         polylineManager.addPolyline(polylineOptions, null)
-        polylineManager.maybeHandleClick("LineString", "polyline-$DEFAULT_UUID")
+        polylineManager.maybeHandleClick("polyline-$DEFAULT_UUID")
 
         // Assert
         verify(exactly = 0) { clickHandler.onPolylineClick(any<OmhPolyline>()) }
@@ -102,7 +89,7 @@ class PolylineManagerTest {
 
         // Act
         polylineManager.addPolyline(polylineOptions, null)
-        polylineManager.maybeHandleClick("LineString", "polyline-$DEFAULT_UUID")
+        polylineManager.maybeHandleClick("polyline-$DEFAULT_UUID")
 
         // Assert
         verify(exactly = 1) { clickHandler.onPolylineClick(any<OmhPolyline>()) }


### PR DESCRIPTION
## Summary
The root cause of the bug was the fact that Mapbox SDK can convert LineString to MultiLineString and Polygon to MultiPolygon when changing the geometry. The fix was to support the "Multi" layer types.

## Demo

[Screen_recording_20240315_093845.webm](https://github.com/openmobilehub/android-omh-maps/assets/23010554/7505ea42-04c3-4b86-9a9b-8786edd3c5c6)

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-166](https://callstackio.atlassian.net/browse/OMHD-166)
