### PR TITLE
OMHD-176: Azure Maps styling

### DIFF
--- a/apps/maps-sample/src/main/java/com/openmobilehub/android/maps/sample/maps/MapStylesFragment.kt
+++ b/apps/maps-sample/src/main/java/com/openmobilehub/android/maps/sample/maps/MapStylesFragment.kt
@@ -21,6 +21,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.RadioGroup
+import androidx.core.view.children
 import androidx.fragment.app.Fragment
 import com.openmobilehub.android.maps.core.presentation.fragments.OmhMapFragment
 import com.openmobilehub.android.maps.core.presentation.interfaces.maps.OmhMap
@@ -29,6 +30,7 @@ import com.openmobilehub.android.maps.core.utils.NetworkConnectivityChecker
 import com.openmobilehub.android.maps.sample.R
 import com.openmobilehub.android.maps.sample.databinding.FragmentMapStylesBinding
 import com.openmobilehub.android.maps.sample.model.InfoDisplay
+import com.openmobilehub.android.maps.sample.utils.Constants
 
 interface MapStyle {
     val dark: Int
@@ -45,12 +47,12 @@ class MapStylesFragment : Fragment(), OmhOnMapReadyCallback {
     private var omhMap: OmhMap? = null
 
     private val mapStyles: Map<String, MapStyle> = mapOf(
-        "GoogleMaps" to object : MapStyle {
+        Constants.GOOGLE_PROVIDER to object : MapStyle {
             override val dark = R.raw.google_style_dark
             override val retro = R.raw.google_style_retro
             override val silver = R.raw.google_style_silver
         },
-        "Mapbox" to object : MapStyle {
+        Constants.MAPBOX_PROVIDER to object : MapStyle {
             override val dark = R.raw.mapbox_style_dark
             override val retro = R.raw.mapbox_style_retro
             override val silver = R.raw.mapbox_style_silver
@@ -83,8 +85,6 @@ class MapStylesFragment : Fragment(), OmhOnMapReadyCallback {
         val omhMapFragment =
             childFragmentManager.findFragmentById(R.id.fragment_map_container) as? OmhMapFragment
         omhMapFragment?.getMapAsync(this)
-
-        setupUI(view)
     }
 
     override fun onMapReady(omhMap: OmhMap) {
@@ -94,10 +94,15 @@ class MapStylesFragment : Fragment(), OmhOnMapReadyCallback {
         }
 
         omhMap.setZoomGesturesEnabled(true)
+
+        view?.let { setupUI(it) }
     }
 
     private fun setupUI(view: View) {
         stylesRadioGroup = view.findViewById(R.id.radioGroup_styles)
+        stylesRadioGroup?.children?.forEach {
+            it.isEnabled = mapStyles.keys.contains(omhMap?.providerName)
+        }
         stylesRadioGroup?.setOnCheckedChangeListener(RadioGroup.OnCheckedChangeListener { _, checkedId ->
             val providerMapStyles =
                 mapStyles[omhMap?.providerName] ?: return@OnCheckedChangeListener

--- a/packages/plugin-azuremaps/README.md
+++ b/packages/plugin-azuremaps/README.md
@@ -60,9 +60,9 @@ This plugin provides support for Azure Maps by utilizing the [Azure Maps Android
 | moveCamera                              |     ✅     |
 | setZoomGesturesEnabled                  |     ✅     |
 | setRotateGesturesEnabled                |     ❌     |
-| setMyLocationEnabled                    |     ?      |
-| isMyLocationEnabled                     |     ?      |
-| setMyLocationButtonClickListener        |     ?      |
+| setMyLocationEnabled                    |     ✅     |
+| isMyLocationEnabled                     |     ✅     |
+| setMyLocationButtonClickListener        |     ✅     |
 | setOnCameraMoveStartedListener          |     ✅     |
 | setOnCameraIdleListener                 |     ✅     |
 | setOnMapLoadedCallback                  |     ✅     |
@@ -74,7 +74,7 @@ This plugin provides support for Azure Maps by utilizing the [Azure Maps Android
 | setOnPolylineClickListener              |     ✅      |
 | setOnPolygonClickListener               |     ?      |
 | snapshot                                |     ❌     |
-| setMapStyle                             |     ?      |
+| setMapStyle                             |     ❌     |
 | setCustomInfoWindowContentsViewFactory  |     ✅     |
 | setCustomInfoWindowViewFactory          |     🟨     |
 

--- a/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMapImpl.kt
+++ b/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMapImpl.kt
@@ -210,7 +210,7 @@ internal class OmhMapImpl(
     }
 
     override fun setMapStyle(json: Int?) {
-        // To be implemented
+        logger.logSetterNotSupported("mapStyle")
     }
 
     override fun setScaleFactor(scaleFactor: Float) {

--- a/packages/plugin-azuremaps/src/test/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMapImplTest.kt
+++ b/packages/plugin-azuremaps/src/test/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMapImplTest.kt
@@ -183,4 +183,16 @@ class OmhMapImplTest {
         // Assert
         verify { myLocationManager.setMyLocationButtonClickListener(listener) }
     }
+
+    @Test
+    fun `setMapStyle calls logger logSetterNotSupported`() {
+        // Arrange
+        val mapStyle = 0
+
+        // Act
+        omhMapImpl.setMapStyle(mapStyle)
+
+        // Assert
+        verify { logger.logSetterNotSupported("mapStyle") }
+    }
 }


### PR DESCRIPTION
## Summary
This PR adds log for Azure Maps `setMapStyle` method and disable the styling options for not supported providers on the `MapStyle` screen.

## Demo

[Screen_recording_20240410_091812.webm](https://github.com/openmobilehub/android-omh-maps/assets/23010554/245bf7be-fc2a-46f8-a188-22d576255873)

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-176](https://callstackio.atlassian.net/browse/OMHD-176)
