### PR TITLE
OMHD-260: Azure Maps - polylines and polygons stroke width affects patterns length #57

### DIFF
--- a/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhPolygonImpl.kt
+++ b/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhPolygonImpl.kt
@@ -99,6 +99,10 @@ internal class OmhPolygonImpl(
         options.strokePattern?.let { _strokePattern = it }
         options.strokeWidth?.let { _strokeWidth = it }
 
+        polygonLayer.setOptions(
+            PolygonLayerOptions.fillOpacity(1.0f)
+        )
+
         applyFillColor()
     }
 


### PR DESCRIPTION
## Summary
Changed polygons default fill opacity so it is consistent with other providers.

## Demo
Before:

![before_20240412_084744](https://github.com/openmobilehub/android-omh-maps/assets/28648651/a6cd4021-b155-44d1-9cfe-76f55b0ddbfb)


After:

![after_20240412_084847](https://github.com/openmobilehub/android-omh-maps/assets/28648651/8dedc592-6fc8-403b-b488-b81079acf53b)

## Checklist:

- [X] Documentation is up to date to reflect these changes
- [X] Created Unit tests

Closes: [OMHD-260](https://callstackio.atlassian.net/browse/OMHD-260)
