### PR TITLE
fix: advanced documentation links and Jekyll configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 [![Discord](https://img.shields.io/discord/1115727214827278446)](https://discord.gg/X8QB9DJXX6)
 ![Apache-2.0](https://img.shields.io/badge/license-Apache-blue)
+![GitHub contributors](https://img.shields.io/github/contributors/openmobilehub/android-omh-maps)
 
-<!--
-// TODO - enable when the repo gets released and is public
-![GitHub contributors](https://img.shields.io/github/contributors/openmobilehub/omh-maps)
--->
+[![CD Workflow](https://github.com/openmobilehub/android-omh-maps/actions/workflows/on_push_workflow.yml/badge.svg)](https://github.com/openmobilehub/android-omh-maps/actions/workflows/on_push_workflow.yml)
+[![CI Workflow](https://github.com/openmobilehub/android-omh-maps/actions/workflows/on_pull_request.yml/badge.svg)](https://github.com/openmobilehub/android-omh-maps/actions/workflows/on_pull_request.yml)
 
-[![Publish Maps API](https://github.com/openmobilehub/omh-maps/actions/workflows/publish_maps_api.yml/badge.svg)](https://github.com/openmobilehub/omh-maps/actions/workflows/publish_maps_api.yml)
-[![Publish Maps API Google Maps Implementation](https://github.com/openmobilehub/omh-maps/actions/workflows/publish_maps_api_gms.yml/badge.svg)](https://github.com/openmobilehub/omh-maps/actions/workflows/publish_maps_api_gms.yml)
-[![Publish Maps API OpenStreetMap Implementation](https://github.com/openmobilehub/omh-maps/actions/workflows/publish_maps_api_ngms.yml/badge.svg)](https://github.com/openmobilehub/omh-maps/actions/workflows/publish_maps_api_ngms.yml)
+[![Publish Core Package](https://github.com/openmobilehub/android-omh-maps/actions/workflows/publish_core.yml/badge.svg)](https://github.com/openmobilehub/android-omh-maps/actions/workflows/publish_core.yml)
+[![Publish Google Maps Plugin](https://github.com/openmobilehub/android-omh-maps/actions/workflows/publish_plugin_googlemaps.yml/badge.svg)](https://github.com/openmobilehub/android-omh-maps/actions/workflows/publish_plugin_googlemaps.yml)
+[![Publish OpenStreetMap Plugin](https://github.com/openmobilehub/android-omh-maps/actions/workflows/publish_plugin_openstreetmap.yml/badge.svg)](https://github.com/openmobilehub/android-omh-maps/actions/workflows/publish_plugin_openstreetmap.yml)
+[![Publish Mapbox Plugin](https://github.com/openmobilehub/android-omh-maps/actions/workflows/publish_plugin_mapbox.yml/badge.svg)](https://github.com/openmobilehub/android-omh-maps/actions/workflows/publish_plugin_mapbox.yml)
+[![Publish Azure Maps Plugin](https://github.com/openmobilehub/android-omh-maps/actions/workflows/publish_plugin_azuremaps.yml/badge.svg)](https://github.com/openmobilehub/android-omh-maps/actions/workflows/publish_plugin_azuremaps.yml)
 
 # OMH Maps Client Library
 
@@ -23,9 +24,10 @@ For instance, the following screenshots showcase multiple devices with Android, 
 <div align="center">
 
 | Google Maps                    | Open Street Maps             | MapBox                          | Azure Maps                     |
-|--------------------------------|------------------------------|---------------------------------|--------------------------------|
+| ------------------------------ | ---------------------------- | ------------------------------- | ------------------------------ |
 | Camera Map                     |
 | <img src="images/gmaps_1.gif"> | <img src="images/osm_1.gif"> | <img src="images/mapbox_1.gif"> | <img src="images/azure_1.gif"> |
+
 </div>
 <details>
   <summary>Show more</summary>
@@ -33,7 +35,7 @@ For instance, the following screenshots showcase multiple devices with Android, 
 <div align="center">
 
 | Google Maps                    | Open Street Maps             | MapBox                          | Azure Maps                     |
-|--------------------------------|------------------------------|---------------------------------|--------------------------------|
+| ------------------------------ | ---------------------------- | ------------------------------- | ------------------------------ |
 | Location Sharing Map           |
 | <img src="images/gmaps_2.gif"> | <img src="images/osm_2.gif"> | <img src="images/mapbox_2.gif"> | <img src="images/azure_2.gif"> |
 | Marker Map                     |
@@ -46,6 +48,7 @@ For instance, the following screenshots showcase multiple devices with Android, 
 | <img src="images/gmaps_6.gif"> | <img src="images/osm_6.gif"> | <img src="images/mapbox_6.gif"> | <img src="images/azure_6.gif"> |
 | Custom Styles Map              |
 | <img src="images/gmaps_7.gif"> | <img src="images/osm_7.png"> | <img src="images/mapbox_7.gif"> | <img src="images/azure_7.png"> |
+
 </div>
 </details>
 
@@ -65,7 +68,7 @@ This section describes how to setup an Android Studio project to use the OMH Map
 To clone the repository and checkout the `starter-code` branch, use the following command in your Terminal:
 
 ```
-git clone --branch starter-code https://github.com/openmobilehub/omh-maps.git
+git clone --branch starter-code https://github.com/openmobilehub/android-omh-maps.git
 ```
 
 ### Provider specific setup
@@ -128,7 +131,7 @@ Fragment has to declare `android:name` that sets the class name of the fragment 
 
    </androidx.constraintlayout.widget.ConstraintLayout>
    ```
-      
+
 2. Click `Run` for the app module.
 
 ## Sample App

--- a/buildSrc/docs-tasks.gradle.kts
+++ b/buildSrc/docs-tasks.gradle.kts
@@ -101,7 +101,7 @@ val copyMarkdownDocsTask = tasks.register("copyMarkdownDocs") {
                 imagesDestDir.deleteRecursively()
             }
 
-            val images = discoverImagesInProject()
+            val images = project.discoverImagesInProject()
             if (images?.isNotEmpty() == true) {
                 imagesDestDir.mkdir()
                 images.forEach { srcImageFile ->

--- a/buildSrc/src/main/kotlin/utils/DocsUtils.kt
+++ b/buildSrc/src/main/kotlin/utils/DocsUtils.kt
@@ -68,8 +68,6 @@ fun Project.getMarkdownDocsOutputDirBase(): File {
 /**
  * Discovers all images in the project's `images/` directory
  *
- * @param rootProject The root project
- * @param project The project to search for images in
  * @return A list of images in the project's `images/` directory
  */
 fun Project.discoverImagesInProject(): List<File>? {

--- a/docs/markdown/_config.yml
+++ b/docs/markdown/_config.yml
@@ -2,8 +2,8 @@ title: OMH Maps advanced docs
 email: contact@openmobilehub.com
 description: >- # this means to ignore newlines until "baseurl:"
   Advanced usage documentation for the OMH Maps library.
-baseurl: "/advanced-docs" # the subpath of your site, e.g. /blog
-url: "https://bookish-eureka-1wmrl6z.pages.github.io" # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: "/android-omh-maps/advanced-docs" # the subpath of your site, e.g. /blog
+url: "https://www.openmobilehub.com/" # the base hostname & protocol for your site, e.g. http://example.com
 github_username: openmobilehub
 
 theme: just-the-docs

--- a/docs/markdown/index.md
+++ b/docs/markdown/index.md
@@ -30,6 +30,6 @@ This is the advanced usage documentation for Open Mobile Hub Maps. Browse the to
 
 You can find the source code for OMH Maps at GitHub:
 [android-omh-maps](https://github.com/openmobilehub/android-omh-maps)
-and the corresponding [API docs here](/)
+and the corresponding [API docs here](https://openmobilehub.com/android-omh-maps/api-docs).
 
 [Open Mobile Hub home page](https://openmobilehub.com)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -7,7 +7,7 @@ The Core package is the backbone of the map feature, mainly providing common int
 ## Documentation
 
 - [API Reference Docs](https://openmobilehub.github.io/omh-maps)
-- [Advanced documentation](/packages/core/docs/advanced/README.md)
+- [Advanced documentation](https://www.openmobilehub.com/android-omh-maps/advanced-docs/core/README/)
 
 ## Contributing
 

--- a/packages/core/docs/advanced/POLYGONS.md
+++ b/packages/core/docs/advanced/POLYGONS.md
@@ -16,7 +16,7 @@ A polygon is a shape with multiple edges on the map. You can customize the appea
 ## Polygon options
 
 Define polygon options for a `Polygon`.
-Many properties can be set. To get the full list of properties, see the [OmhPolygonOptions](TODO: Add missing link) class.
+Many properties can be set. To get the full list of properties, see the [OmhPolygonOptions](https://www.openmobilehub.com/android-omh-maps/api-docs/packages/core/com.openmobilehub.android.maps.core.presentation.models/-omh-polygon-options/index.html){:target="\_blank"} class.
 Example of usage of `OmhPolygonOptions` and `addPolygon(OmhPolygonOptions)`:
 
 ```kotlin
@@ -37,7 +37,7 @@ val polygon = omhMap.addPolygon(omhPolygonOptions)
 ## Modifying an existing Polygon
 
 Once a Polygon is added to the map, you can modify its properties by calling the methods of the `OmhPolygon` class.
-To get the full list of methods, see the [OmhPolygon](TODO: Add missing link) class. Example of usage of `OmhPolygon` methods:
+To get the full list of methods, see the [OmhPolygon](https://www.openmobilehub.com/android-omh-maps/api-docs/packages/core/com.openmobilehub.android.maps.core.presentation.interfaces.maps/-omh-polygon/index.html){:target="\_blank"} class. Example of usage of `OmhPolygon` methods:
 
 ```kotlin
 polygon.setFillColor(Color.BLUE)

--- a/packages/core/docs/advanced/POLYLINES.md
+++ b/packages/core/docs/advanced/POLYLINES.md
@@ -17,7 +17,7 @@ To add a polyline call the function `fun addPolyline(OmhPolylineOptions): OmhPol
 ## Polyline options
 
 Define polyline options for a `Polyline`.
-Many properties can be set. To get the full list of properties, see the [OmhPolylineOptions](TODO: Add missing link) class.
+Many properties can be set. To get the full list of properties, see the [OmhPolylineOptions](https://www.openmobilehub.com/android-omh-maps/api-docs/packages/core/com.openmobilehub.android.maps.core.presentation.models/-omh-polyline-options/index.html){:target="\_blank"} class.
 Example of usage of `OmhPolylineOptions` and `addPolyline(OmhPolylineOptions)`:
 
 ```kotlin
@@ -37,7 +37,7 @@ val polyline = omhMap.addPolyline(omhPolylineOptions)
 ## Modifying an existing polyline
 
 Once a polyline is added to the map, you can modify its properties by calling the methods of the `OmhPolyline` class.
-To get the full list of methods, see the [OmhPolyline](TODO: Add missing link) class. Example of usage of `OmhPolyline` methods:
+To get the full list of methods, see the [OmhPolyline](https://www.openmobilehub.com/android-omh-maps/api-docs/packages/core/com.openmobilehub.android.maps.core.presentation.interfaces.maps/-omh-polyline/index.html){:target="\_blank"} class. Example of usage of `OmhPolyline` methods:
 
 ```kotlin
 polyline.setColor(Color.BLUE)

--- a/packages/plugin-azuremaps/README.md
+++ b/packages/plugin-azuremaps/README.md
@@ -15,8 +15,8 @@ This plugin provides support for Azure Maps by utilizing the [Azure Maps Android
 
 1. Add the plugin to the project by following one of the guides:
 
-- [Setup with omh-core plugin](/packages/core/docs/SETUP_WITH_OMH_CORE_PLUGIN.md)
-- [Setup without omh-core plugin](/packages/core/docs/SETUP_WITHOUT_OMH_CORE_PLUGIN.md)
+- [Setup with omh-core plugin](https://www.openmobilehub.com/android-omh-maps/advanced-docs/core/SETUP_WITH_OMH_CORE_PLUGIN/)
+- [Setup without omh-core plugin](https://www.openmobilehub.com/android-omh-maps/advanced-docs/core/SETUP_WITHOUT_OMH_CORE_PLUGIN/)
 
 2. Configure credentials according to the [Official Documentation](https://learn.microsoft.com/en-us/azure/azure-maps/quick-android-map?pivots=programming-language-kotlin#create-an-azure-maps-account)
 
@@ -80,9 +80,9 @@ This plugin provides support for Azure Maps by utilizing the [Azure Maps Android
 
 Comments for partially supported 🟨 properties:
 
-| Property                       | Comments                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| setCustomInfoWindowViewFactory | The provider supports this method in full, however since the view is rendered "live" (i.e., the view is mounted instead of being rendered to a bitmap), attaching interaction listeners to the root view returned by the factory is forbidden. Please consult the [advanced documentation](https://todo.todo) of this plugin for more information. |
+| Property                       | Comments                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| setCustomInfoWindowViewFactory | The provider supports this method in full, however since the view is rendered "live" (i.e., the view is mounted instead of being rendered to a bitmap), attaching interaction listeners to the root view returned by the factory is forbidden. Please consult the [advanced documentation](https://www.openmobilehub.com/android-omh-maps/advanced-docs/plugin-azuremaps/advanced/INFO_WINDOWS/) of this plugin for more information. |
 
 ### Marker
 

--- a/packages/plugin-googlemaps/README.md
+++ b/packages/plugin-googlemaps/README.md
@@ -22,8 +22,8 @@ Complete the required Cloud Console setup following the next steps, for more inf
 
 1. Add the plugin to the project by following one of the guides:
 
-- [Setup with omh-core plugin](/packages/core/docs/SETUP_WITH_OMH_CORE_PLUGIN.md)
-- [Setup without omh-core plugin](/packages/core/docs/SETUP_WITHOUT_OMH_CORE_PLUGIN.md)
+- [Setup with omh-core plugin](https://www.openmobilehub.com/android-omh-maps/advanced-docs/core/SETUP_WITH_OMH_CORE_PLUGIN/)
+- [Setup without omh-core plugin](https://www.openmobilehub.com/android-omh-maps/advanced-docs/core/SETUP_WITHOUT_OMH_CORE_PLUGIN/)
 
 2. Configure API key according to the [Official Documentation](https://developers.google.com/maps/documentation/android-sdk/start#add-key).
 

--- a/packages/plugin-mapbox/README.md
+++ b/packages/plugin-mapbox/README.md
@@ -15,8 +15,8 @@ This plugin provides support for Mapbox by utilizing the [Mapbox Android SDK](ht
 
 1. Add the plugin to the project by following one of the guides:
 
-- [Setup with omh-core plugin](/packages/core/docs/SETUP_WITH_OMH_CORE_PLUGIN.md)
-- [Setup without omh-core plugin](/packages/core/docs/SETUP_WITHOUT_OMH_CORE_PLUGIN.md)
+- [Setup with omh-core plugin](https://www.openmobilehub.com/android-omh-maps/advanced-docs/core/SETUP_WITH_OMH_CORE_PLUGIN/)
+- [Setup without omh-core plugin](https://www.openmobilehub.com/android-omh-maps/advanced-docs/core/SETUP_WITHOUT_OMH_CORE_PLUGIN/)
 
 2. Configure credentials according the [Official Documentation](https://docs.mapbox.com/android/maps/guides/install#configure-credentials).
 
@@ -186,8 +186,6 @@ Comments for partially supported 🟨 properties:
 | isVisible    |     ✅     |
 | setVisible   |     ✅     |
 | remove       |     ✅     |
-
-
 
 ### Polygon
 

--- a/packages/plugin-openstreetmap/README.md
+++ b/packages/plugin-openstreetmap/README.md
@@ -15,8 +15,8 @@ This plugin provides support for OpenStreetMap maps by utilizing the [osmdroid](
 
 1. Add the plugin to the project by following one of the guides:
 
-- [Setup with omh-core plugin](/packages/core/docs/SETUP_WITH_OMH_CORE_PLUGIN.md)
-- [Setup without omh-core plugin](/packages/core/docs/SETUP_WITHOUT_OMH_CORE_PLUGIN.md)
+- [Setup with omh-core plugin](https://www.openmobilehub.com/android-omh-maps/advanced-docs/core/SETUP_WITH_OMH_CORE_PLUGIN/)
+- [Setup without omh-core plugin](https://www.openmobilehub.com/android-omh-maps/advanced-docs/core/SETUP_WITHOUT_OMH_CORE_PLUGIN/)
 
 2. In your app's module-level `AndroidManifest.xml` add the required permissions, for more information see [permissions](https://developer.android.com/training/permissions/declaring).
 
@@ -74,10 +74,10 @@ Legend of support levels:
 
 Comments for partially supported 🟨 properties:
 
-| Property                       | Comments                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| setOnCameraMoveStartedListener | The reason of the camera changed started is unknown                                                                                                                                                                                                                                                                                                |
-| setCustomInfoWindowViewFactory | The provider supports this method in full, however since the view is rendered "live" (i.e., the view is mounted instead of being rendered to a bitmap), attaching interaction listeners to the root view returned by the factory is forbidden. Please consult the [advanced documentation](https://todo.todo) of this plugin for more information. |
+| Property                       | Comments                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| setOnCameraMoveStartedListener | The reason of the camera changed started is unknown                                                                                                                                                                                                                                                                                                                                                                                       |
+| setCustomInfoWindowViewFactory | The provider supports this method in full, however since the view is rendered "live" (i.e., the view is mounted instead of being rendered to a bitmap), attaching interaction listeners to the root view returned by the factory is forbidden. Please consult the [advanced documentation](https://www.openmobilehub.com/android-omh-maps/advanced-docs/plugin-openstreetmap/advanced/INFO_WINDOWS/) of this plugin for more information. |
 
 ### Marker
 
@@ -181,10 +181,9 @@ Comments for partially supported 🟨 properties:
 | setVisible   |     ✅     |
 | remove       |     ✅     |
 
-
 | Property | Comments                                                                |
-| -------- | ----------------------------------------------------------------------- |
-| setCap   | It applies not only to start and end cap, but to polyline joins as well |                                                                                                                                                                                                                                                                                              |
+| -------- | ----------------------------------------------------------------------- | --- |
+| setCap   | It applies not only to start and end cap, but to polyline joins as well |     |
 
 ### Polygon
 


### PR DESCRIPTION
## Summary

This PR introduces the following fixes for documentation:
- fixes #63 by configuring Jekyll to bundle the files with proper links for hosting on the final domain in a subdirectory
- fixes #65 by correcting the links to point to the OMH project domain
- fixes large docs bundle size with new GIFs due to a bug in `docs-tasks.gradle.kts` that called `discoverImagesInProject()` on `rootProject` instead of on all iterated subprojects

## Demo

N/A

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-273](https://callstackio.atlassian.net/browse/OMHD-273)
Closes: [OMHD-274](https://callstackio.atlassian.net/browse/OMHD-274)
