### PR TITLE
fix: update sample app MapMarkersFragment to disable controls when the customizable marker is removed and to feature a customizable marker restore button

### DIFF
--- a/apps/maps-sample/src/main/java/com/openmobilehub/android/maps/sample/customviews/PanelColorSeekbar.kt
+++ b/apps/maps-sample/src/main/java/com/openmobilehub/android/maps/sample/customviews/PanelColorSeekbar.kt
@@ -67,4 +67,8 @@ class PanelColorSeekbar @JvmOverloads constructor(
 
         customSeekBar.isEnabled = enabled
     }
+
+    fun setProgress(progress: Int) {
+        customSeekBar.progress = progress
+    }
 }

--- a/apps/maps-sample/src/main/java/com/openmobilehub/android/maps/sample/customviews/PanelSpinner.kt
+++ b/apps/maps-sample/src/main/java/com/openmobilehub/android/maps/sample/customviews/PanelSpinner.kt
@@ -47,7 +47,7 @@ class PanelSpinner @JvmOverloads constructor(
     }
 
     private fun getResourceStrings(resourceIds: IntArray): MutableList<String> {
-        val strings = mutableListOf<String>();
+        val strings = mutableListOf<String>()
         for (i in resourceIds.indices) {
             strings.add(context.getString(resourceIds[i]))
         }
@@ -71,7 +71,7 @@ class PanelSpinner @JvmOverloads constructor(
                 position: Int,
                 convertView: View?,
                 parent: ViewGroup
-            ): View? {
+            ): View {
                 val textView = super.getDropDownView(position, convertView, parent) as TextView
 
                 textView.isEnabled = positionEnabled(position)
@@ -103,8 +103,12 @@ class PanelSpinner @JvmOverloads constructor(
         spinner.isEnabled = enabled
         titleTextView.alpha = if (enabled) 1.0f else 0.5f
     }
-    
+
     fun setDisabledPositions(disabledPositions: HashSet<Int>?) {
         this.disabledPositions = disabledPositions
+    }
+
+    fun setSelection(position: Int) {
+        spinner.setSelection(position)
     }
 }

--- a/apps/maps-sample/src/main/java/com/openmobilehub/android/maps/sample/maps/MapMarkersFragment.kt
+++ b/apps/maps-sample/src/main/java/com/openmobilehub/android/maps/sample/maps/MapMarkersFragment.kt
@@ -136,9 +136,7 @@ open class MapMarkersFragment : Fragment(), OmhOnMapReadyCallback {
         rotationSeekbar?.isEnabled = enabled
     }
 
-    private fun maybeAddCustomizableMarker() {
-        if (customizableMarker != null) return
-
+    private fun addCustomizableMarker() {
         customizableMarker = omhMap?.addMarker(OmhMarkerOptions().apply {
             title = "Configurable test marker"
             position = OmhCoordinate().apply {
@@ -181,7 +179,7 @@ open class MapMarkersFragment : Fragment(), OmhOnMapReadyCallback {
             draggable = true
         })
 
-        maybeAddCustomizableMarker()
+        addCustomizableMarker()
 
         omhMap.setOnMarkerClickListener(OmhOnMarkerClickListener { marker ->
             Log.d(
@@ -394,8 +392,9 @@ open class MapMarkersFragment : Fragment(), OmhOnMapReadyCallback {
             view.findViewById(R.id.button_demoRestoreCustomizableMarker)
         restoreCustomizableMarkerButton?.isEnabled = false
         restoreCustomizableMarkerButton?.setOnClickListener {
-            maybeAddCustomizableMarker()
+            if (customizableMarker == null) addCustomizableMarker()
 
+            // ensure the marker was successfully added first
             if (customizableMarker != null) {
                 applyDefaultCustomizableMarkerControlOptions()
                 setCustomizableMarkerControlsEnabled(true)

--- a/apps/maps-sample/src/main/java/com/openmobilehub/android/maps/sample/maps/MapMarkersFragment.kt
+++ b/apps/maps-sample/src/main/java/com/openmobilehub/android/maps/sample/maps/MapMarkersFragment.kt
@@ -23,6 +23,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import android.widget.CheckBox
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.res.ResourcesCompat
@@ -57,6 +58,7 @@ open class MapMarkersFragment : Fragment(), OmhOnMapReadyCallback {
     private var handler: Handler? = null
     private var runnable: Runnable? = null
 
+    private var omhMap: OmhMap? = null
     private var customizableMarker: OmhMarker? = null
 
     private var isClickableCheckbox: CheckBox? = null
@@ -71,6 +73,7 @@ open class MapMarkersFragment : Fragment(), OmhOnMapReadyCallback {
     private var appearanceSpinner: PanelSpinner? = null
     private var colorSeekbar: PanelColorSeekbar? = null
     private var rotationSeekbar: PanelSeekbar? = null
+    private var restoreCustomizableMarkerButton: Button? = null
     private var customizableMarkerAnchor: Pair<Float, Float> =
         Pair(Constants.ANCHOR_CENTER, Constants.ANCHOR_CENTER)
     private var customBackgroundColor: Int = Color.parseColor("#FFEA393F")
@@ -117,7 +120,39 @@ open class MapMarkersFragment : Fragment(), OmhOnMapReadyCallback {
         setupUI(view)
     }
 
+    private fun setCustomizableMarkerControlsEnabled(enabled: Boolean) {
+        restoreCustomizableMarkerButton?.isEnabled = !enabled
+
+        isVisibleCheckbox?.isEnabled = enabled
+        isFlatCheckbox?.isEnabled = enabled
+        isClickableCheckbox?.isEnabled = enabled
+        isDraggableCheckbox?.isEnabled = enabled
+        hasSnippetCheckbox?.isEnabled = enabled
+        anchorUSeekbar?.isEnabled = enabled
+        anchorVSeekbar?.isEnabled = enabled
+        alphaSeekbar?.isEnabled = enabled
+        appearanceSpinner?.isEnabled = enabled
+        colorSeekbar?.isEnabled = enabled
+        rotationSeekbar?.isEnabled = enabled
+    }
+
+    private fun maybeAddCustomizableMarker() {
+        if (customizableMarker != null) return
+
+        customizableMarker = omhMap?.addMarker(OmhMarkerOptions().apply {
+            title = "Configurable test marker"
+            position = OmhCoordinate().apply {
+                latitude = PRIME_MERIDIAN.latitude - 0.001
+                longitude = PRIME_MERIDIAN.longitude
+            }
+            draggable = true
+        })
+    }
+
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
     override fun onMapReady(omhMap: OmhMap) {
+        this.omhMap = omhMap
+
         mapProviderName = omhMap.providerName
 
         if (networkConnectivityChecker?.isNetworkAvailable() != true) {
@@ -146,14 +181,7 @@ open class MapMarkersFragment : Fragment(), OmhOnMapReadyCallback {
             draggable = true
         })
 
-        customizableMarker = omhMap.addMarker(OmhMarkerOptions().apply {
-            title = "Configurable test marker"
-            position = OmhCoordinate().apply {
-                latitude = PRIME_MERIDIAN.latitude - 0.001
-                longitude = PRIME_MERIDIAN.longitude
-            }
-            draggable = true
-        })
+        maybeAddCustomizableMarker()
 
         omhMap.setOnMarkerClickListener(OmhOnMarkerClickListener { marker ->
             Log.d(
@@ -165,6 +193,12 @@ open class MapMarkersFragment : Fragment(), OmhOnMapReadyCallback {
 
             if (shouldRemoveMarker) {
                 marker.remove()
+
+                if (marker == customizableMarker) {
+                    customizableMarker = null
+
+                    setCustomizableMarkerControlsEnabled(false)
+                }
             }
 
             infoDisplay.showMessage(
@@ -212,6 +246,11 @@ open class MapMarkersFragment : Fragment(), OmhOnMapReadyCallback {
             it.hideInfoWindow()
         }
 
+        applyDefaultCustomizableMarkerControlOptions()
+    }
+
+    private fun applyDefaultCustomizableMarkerControlOptions() {
+        rotationSeekbar?.setProgress(0)
         isVisibleCheckbox?.isChecked = customizableMarker?.getIsVisible() ?: true
         isFlatCheckbox?.isChecked = customizableMarker?.getIsFlat() ?: false
         isClickableCheckbox?.isClickable = customizableMarker?.getClickable() ?: true
@@ -232,6 +271,16 @@ open class MapMarkersFragment : Fragment(), OmhOnMapReadyCallback {
         }
 
         appearanceSpinner?.setDisabledPositions(disabledAppearancePositions)
+        appearanceSpinner?.setSelection(
+            markerAppearanceTypeNameResourceID.indexOf(
+                markerAppearanceTypeNameResourceID.first {
+                    !(disabledAppearancePositions?.contains(
+                        it
+                    ) ?: false)
+                })
+        )
+        colorSeekbar?.setProgress(0)
+        applyCustomizableMarkerAppearance()
     }
 
     private fun applyCustomizableMarkerAnchor() {
@@ -339,6 +388,19 @@ open class MapMarkersFragment : Fragment(), OmhOnMapReadyCallback {
         demoShouldRemoveMarkerOnClickCheckBox =
             view.findViewById(R.id.checkBox_demoShouldRemoveMarkerOnClick)
         demoShouldRemoveMarkerOnClickCheckBox?.isChecked = false
+
+        // demo restore customizable marker button
+        restoreCustomizableMarkerButton =
+            view.findViewById(R.id.button_demoRestoreCustomizableMarker)
+        restoreCustomizableMarkerButton?.isEnabled = false
+        restoreCustomizableMarkerButton?.setOnClickListener {
+            maybeAddCustomizableMarker()
+
+            if (customizableMarker != null) {
+                applyDefaultCustomizableMarkerControlOptions()
+                setCustomizableMarkerControlsEnabled(true)
+            }
+        }
     }
 
     override fun onResume() {

--- a/apps/maps-sample/src/main/res/layout/fragment_map_markers.xml
+++ b/apps/maps-sample/src/main/res/layout/fragment_map_markers.xml
@@ -165,6 +165,13 @@
                 android:layout_height="wrap_content"
                 android:checked="true"
                 android:text="@string/remove_marker_on_click" />
+
+            <Button
+                android:id="@+id/button_demoRestoreCustomizableMarker"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginBottom="80dp"
+                android:text="@string/label_demo_button_restore_customizable_marker" />
         </LinearLayout>
     </ScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/maps-sample/src/main/res/values/strings.xml
+++ b/apps/maps-sample/src/main/res/values/strings.xml
@@ -124,4 +124,5 @@
     <string name="remove_marker_on_click">Remove marker on click</string>
     <string name="show_reference_polyline">Show Reference Polyline (Add/Remove)</string>
     <string name="show_reference_polygon">Show Reference Polygon (Add/Remove)</string>
+    <string name="label_demo_button_restore_customizable_marker">Restore customizable marker</string>
 </resources>


### PR DESCRIPTION
## Summary

This PR introduces a fix to the 'Marker Map' demo by disabling all customizable marker controls when the marker is removed from the map by the user.
It also brings a 'Restore customizable marker' button to restore the customizable marker (enabled when it is removed), which restores the marker with the default options and resets the controls for these options to default values as well. An additional margin to the bottom was added according to QA's suggestions for ease of use so that the snackbar does not cover marker demo controls.

## Demo

https://github.com/openmobilehub/android-omh-maps/assets/10586109/191b22f9-ba4b-46c5-9b40-3850f3e78f71

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-268](https://callstackio.atlassian.net/browse/OMHD-268)
