### PR TITLE
fix: set conditional controls enabled state after unlocking controls when marker was removed

### DIFF
--- a/apps/maps-sample/src/main/java/com/openmobilehub/android/maps/sample/maps/MapMarkersFragment.kt
+++ b/apps/maps-sample/src/main/java/com/openmobilehub/android/maps/sample/maps/MapMarkersFragment.kt
@@ -396,8 +396,8 @@ open class MapMarkersFragment : Fragment(), OmhOnMapReadyCallback {
 
             // ensure the marker was successfully added first
             if (customizableMarker != null) {
-                applyDefaultCustomizableMarkerControlOptions()
                 setCustomizableMarkerControlsEnabled(true)
+                applyDefaultCustomizableMarkerControlOptions()
             }
         }
     }


### PR DESCRIPTION
## Summary

This PR fixes the order in which controls are unlocked after the user removes and restores the customizable marker on marker demo screen: first enables controls and then conditionally disables inapplicable controls, also setting them to default values, which fixes a bug resulting in inapplicable controls (that should be disabled) becoming active.

## Demo

N/A

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-275](https://callstackio.atlassian.net/browse/OMHD-275)
