### PR TITLE
feat: marker zIndex support

### DIFF
--- a/apps/maps-sample/src/main/java/com/openmobilehub/android/maps/sample/maps/MapMarkersFragment.kt
+++ b/apps/maps-sample/src/main/java/com/openmobilehub/android/maps/sample/maps/MapMarkersFragment.kt
@@ -70,6 +70,7 @@ open class MapMarkersFragment : Fragment(), OmhOnMapReadyCallback {
     private var anchorUSeekbar: PanelSeekbar? = null
     private var anchorVSeekbar: PanelSeekbar? = null
     private var alphaSeekbar: PanelSeekbar? = null
+    private var zIndexSeekbar: PanelSeekbar? = null
     private var appearanceSpinner: PanelSpinner? = null
     private var colorSeekbar: PanelColorSeekbar? = null
     private var rotationSeekbar: PanelSeekbar? = null
@@ -134,6 +135,7 @@ open class MapMarkersFragment : Fragment(), OmhOnMapReadyCallback {
         appearanceSpinner?.isEnabled = enabled
         colorSeekbar?.isEnabled = enabled
         rotationSeekbar?.isEnabled = enabled
+        zIndexSeekbar?.isEnabled = enabled
     }
 
     private fun addCustomizableMarker() {
@@ -165,6 +167,7 @@ open class MapMarkersFragment : Fragment(), OmhOnMapReadyCallback {
             position = OmhCoordinate().apply {
                 latitude = PRIME_MERIDIAN.latitude + 0.0016
                 longitude = PRIME_MERIDIAN.longitude + 0.002
+                zIndex = 1.9f
             }
             icon = ResourcesCompat.getDrawable(resources, R.drawable.ic_map_marker, null)
         })
@@ -174,6 +177,7 @@ open class MapMarkersFragment : Fragment(), OmhOnMapReadyCallback {
             position = OmhCoordinate().apply {
                 latitude = PRIME_MERIDIAN.latitude + 0.0016
                 longitude = PRIME_MERIDIAN.longitude - 0.002
+                zIndex = 2.9f
             }
             backgroundColor = 0xFF005918.toInt() // green-ish
             draggable = true
@@ -257,6 +261,9 @@ open class MapMarkersFragment : Fragment(), OmhOnMapReadyCallback {
         anchorUSeekbar?.setProgress(50)
         anchorVSeekbar?.setProgress(50)
         alphaSeekbar?.setProgress(100)
+        zIndexSeekbar?.setProgress(0)
+        zIndexSeekbar?.isEnabled =
+            mapProviderName == com.openmobilehub.android.maps.sample.utils.Constants.GOOGLE_PROVIDER
 
         if (mapProviderName == OSM_PROVIDER) {
             disabledAppearancePositions =
@@ -399,6 +406,12 @@ open class MapMarkersFragment : Fragment(), OmhOnMapReadyCallback {
                 setCustomizableMarkerControlsEnabled(true)
                 applyDefaultCustomizableMarkerControlOptions()
             }
+        }
+
+        // zIndex
+        zIndexSeekbar = view.findViewById(R.id.panelSeekbar_zIndex)
+        zIndexSeekbar?.setOnProgressChangedCallback { progress: Int ->
+            customizableMarker?.setZIndex(progress.toFloat())
         }
     }
 

--- a/apps/maps-sample/src/main/res/layout/fragment_map_markers.xml
+++ b/apps/maps-sample/src/main/res/layout/fragment_map_markers.xml
@@ -150,6 +150,16 @@
                 android:layout_marginBottom="15dp"
                 app:titleText="@string/color" />
 
+            <com.openmobilehub.android.maps.sample.customviews.PanelSeekbar
+                android:id="@+id/panelSeekbar_zIndex"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="15dp"
+                android:layout_marginBottom="15dp"
+                app:maxValue="5"
+                app:minValue="0"
+                app:titleText="@string/z_index" />
+
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/packages/core/src/main/java/com/openmobilehub/android/maps/core/presentation/interfaces/maps/OmhMarker.kt
+++ b/packages/core/src/main/java/com/openmobilehub/android/maps/core/presentation/interfaces/maps/OmhMarker.kt
@@ -227,4 +227,18 @@ interface OmhMarker {
      * Removes the marker from the map.
      */
     fun remove()
+
+    /**
+     * Gets the zIndex of the marker, which specifies the order in which the marker is drawn on the map.
+     *
+     * @return the zIndex of the marker or null if not set.
+     */
+    fun getZIndex(): Float?
+
+    /**
+     * Sets the zIndex of the marker, which specifies the order in which the marker is drawn on the map.
+     *
+     * @param zIndex the zIndex of the marker.
+     */
+    fun setZIndex(zIndex: Float)
 }

--- a/packages/core/src/main/java/com/openmobilehub/android/maps/core/presentation/models/OmhMarkerOptions.kt
+++ b/packages/core/src/main/java/com/openmobilehub/android/maps/core/presentation/models/OmhMarkerOptions.kt
@@ -56,6 +56,7 @@ object Constants {
  * **NOTE:** please remember to pass color integers with set bytes corresponding
  * to alpha channel (e.g. of shape `0xAARRGGBB`).
  * @property icon The icon [Drawable] for the marker. Overrides [backgroundColor] if not null.
+ * @property zIndex The z-index of the marker. Default: `null`
  */
 @Keep
 @Parcelize
@@ -76,5 +77,6 @@ data class OmhMarkerOptions(
     var isFlat: Boolean = Constants.DEFAULT_IS_FLAT,
     var rotation: Float = Constants.DEFAULT_ROTATION,
     @ColorInt var backgroundColor: Int? = null,
-    @IgnoredOnParcel var icon: Drawable? = null
+    @IgnoredOnParcel var icon: Drawable? = null,
+    var zIndex: Float? = null
 ) : Parcelable

--- a/packages/plugin-azuremaps/README.md
+++ b/packages/plugin-azuremaps/README.md
@@ -102,6 +102,7 @@ Comments for partially supported 🟨 properties:
 | rotation         |      ✅       |
 | backgroundColor  |      ✅       |
 | clickable        |      ✅       |
+| zIndex           |      ❌       |
 
 Comments for partially supported 🟨 properties:
 
@@ -140,6 +141,8 @@ Comments for partially supported 🟨 properties:
 | hideInfoWindow       |      ✅       |
 | getIsInfoWindowShown |      ✅       |
 | remove               |      ✅       |
+| getZIndex            |      ❌       |
+| setZIndex            |      ❌       |
 
 Comments for partially supported 🟨 properties:
 

--- a/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/extensions/OmhMarkerExtensions.kt
+++ b/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/extensions/OmhMarkerExtensions.kt
@@ -32,6 +32,10 @@ internal fun OmhMarkerOptions.toSymbolLayerOptionsList(
         logger.logNotSupported("draggable")
     }
 
+    zIndex.let {
+        logger.logNotSupported("zIndex")
+    }
+
     return listOf<Option<*>>(
         // icon
         SymbolLayerOptions.iconSize(1f), // icon scale
@@ -54,6 +58,6 @@ internal fun OmhMarkerOptions.toSymbolLayerOptionsList(
         SymbolLayerOptions.iconRotation(rotation),
 
         // isFlat
-        SymbolLayerOptions.iconRotationAlignment(OmhMarkerImpl.getIconsRotationAlignment(isFlat))
+        SymbolLayerOptions.iconRotationAlignment(OmhMarkerImpl.getIconsRotationAlignment(isFlat)),
     )
 }

--- a/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMarkerImpl.kt
+++ b/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMarkerImpl.kt
@@ -362,6 +362,15 @@ internal class OmhMarkerImpl(
         omhInfoWindow.remove()
     }
 
+    override fun getZIndex(): Float? {
+        logger.logGetterNotSupported("zIndex")
+        return null
+    }
+
+    override fun setZIndex(zIndex: Float) {
+        logger.logSetterNotSupported("zIndex")
+    }
+
     internal companion object {
         internal fun getIconsRotationAlignment(isFlat: Boolean): String {
             return if (isFlat) {

--- a/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/managers/MapMarkerManager.kt
+++ b/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/managers/MapMarkerManager.kt
@@ -29,6 +29,7 @@ import com.openmobilehub.android.maps.core.presentation.interfaces.maps.OmhOnInf
 import com.openmobilehub.android.maps.core.presentation.interfaces.maps.OmhOnInfoWindowOpenStatusChangeListener
 import com.openmobilehub.android.maps.core.presentation.interfaces.maps.OmhOnMarkerClickListener
 import com.openmobilehub.android.maps.core.presentation.models.OmhMarkerOptions
+import com.openmobilehub.android.maps.core.utils.logging.UnsupportedFeatureLogger
 import com.openmobilehub.android.maps.core.utils.uuid.DefaultUUIDGenerator
 import com.openmobilehub.android.maps.core.utils.uuid.UUIDGenerator
 import com.openmobilehub.android.maps.plugin.azuremaps.extensions.toSymbolLayerOptionsList
@@ -39,6 +40,7 @@ import com.openmobilehub.android.maps.plugin.azuremaps.presentation.maps.OmhInfo
 import com.openmobilehub.android.maps.plugin.azuremaps.presentation.maps.OmhMarkerImpl
 import com.openmobilehub.android.maps.plugin.azuremaps.utils.Constants
 import com.openmobilehub.android.maps.plugin.azuremaps.utils.CoordinateConverter
+import com.openmobilehub.android.maps.plugin.azuremaps.utils.markerLogger
 import java.util.UUID
 
 @SuppressWarnings("TooManyFunctions")
@@ -55,7 +57,8 @@ internal class MapMarkerManager(
 
     fun addMarker(
         options: OmhMarkerOptions,
-        uuidGenerator: UUIDGenerator = DefaultUUIDGenerator()
+        uuidGenerator: UUIDGenerator = DefaultUUIDGenerator(),
+        logger: UnsupportedFeatureLogger = markerLogger
     ): OmhMarkerImpl {
         val markerUUID = uuidGenerator.generate()
         val pointOnMap = CoordinateConverter.convertToPoint(options.position)
@@ -72,7 +75,7 @@ internal class MapMarkerManager(
             markerDataSource,
             OmhMarkerImpl.getSymbolLayerID(markerUUID)
         )
-        for (option in options.toSymbolLayerOptionsList()) {
+        for (option in options.toSymbolLayerOptionsList(logger)) {
             markerLayer.setOptions(option)
         }
         map.layers.add(markerLayer)
@@ -99,7 +102,8 @@ internal class MapMarkerManager(
             rotation = options.rotation,
             infoWindowPopup = infoWindowPopup,
             mapViewDelegate = this,
-            markerDelegate = this
+            markerDelegate = this,
+            logger = logger
         )
 
         val omhMarkerUUIDStr = omhMarker.markerUUID.toString()

--- a/packages/plugin-azuremaps/src/test/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/managers/MapMarkerManagerTest.kt
+++ b/packages/plugin-azuremaps/src/test/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/managers/MapMarkerManagerTest.kt
@@ -22,6 +22,7 @@ import com.openmobilehub.android.maps.core.presentation.interfaces.maps.OmhOnInf
 import com.openmobilehub.android.maps.core.presentation.interfaces.maps.OmhOnMarkerClickListener
 import com.openmobilehub.android.maps.core.presentation.models.OmhMarkerOptions
 import com.openmobilehub.android.maps.core.utils.DrawableConverter
+import com.openmobilehub.android.maps.core.utils.logging.UnsupportedFeatureLogger
 import com.openmobilehub.android.maps.plugin.azuremaps.presentation.interfaces.AzureMapInterface
 import io.mockk.every
 import io.mockk.mockk
@@ -45,6 +46,7 @@ class MapMarkerManagerTest {
     private val defaultMarkerIconDrawable = mockk<Drawable>()
     private val convertDrawableToBitmapMock = mockk<Bitmap>()
     private val iwMockFrameLayout = mockk<FrameLayout>(relaxed = true)
+    private val mockLogger = mockk<UnsupportedFeatureLogger>(relaxed = true)
 
     @Before
     fun setUp() {
@@ -111,15 +113,6 @@ class MapMarkerManagerTest {
     @Test
     fun `setCustomInfoWindowViewFactory sets custom IW view factory`() {
         // Arrange
-//        mockkConstructor(OmhInfoWindow::class)
-//        var capturedInfoWindowViewFactory: OmhInfoWindowViewFactory? = null
-//        every { anyConstructed<OmhInfoWindow>().setCustomInfoWindowViewFactory(any()) } answers {
-//            capturedInfoWindowViewFactory = firstArg()
-//        }
-//        var capturedInfoWindowContentsViewFactory: OmhInfoWindowViewFactory? = null
-//        every { anyConstructed<OmhInfoWindow>().setCustomInfoWindowContentsViewFactory(any()) } answers {
-//            capturedInfoWindowContentsViewFactory = firstArg()
-//        }
         val marker = mapMarkerManager.addMarker(OmhMarkerOptions())
 
         val mockedIWView = mockk<View>(relaxed = true)
@@ -237,5 +230,41 @@ class MapMarkerManagerTest {
 
         // Assert
         verify(exactly = 1) { omhOnIWLongClickListener.onInfoWindowLongClick(marker) }
+    }
+
+    @Test
+    fun `getZIndex should return null and log getter not supported`() {
+        // Act
+        val result = mapMarkerManager.addMarker(OmhMarkerOptions(), logger = mockLogger).getZIndex()
+
+        // Assert
+        Assert.assertNull(result)
+        verify { mockLogger.logGetterNotSupported("zIndex") }
+    }
+
+    @Test
+    fun `setZIndex should log setter not supported`() {
+        // Act
+        mapMarkerManager.addMarker(
+            OmhMarkerOptions(),
+            logger = mockLogger
+        ).setZIndex(1.0f)
+
+        // Assert
+        verify { mockLogger.logSetterNotSupported("zIndex") }
+    }
+
+    @Test
+    fun `OmhMarkerOptions should log zIndex not supported when passed`() {
+        // Act
+        mapMarkerManager.addMarker(
+            OmhMarkerOptions().apply {
+                zIndex = 1.0f
+            },
+            logger = mockLogger
+        )
+
+        // Assert
+        verify { mockLogger.logNotSupported("zIndex") }
     }
 }

--- a/packages/plugin-googlemaps/README.md
+++ b/packages/plugin-googlemaps/README.md
@@ -106,6 +106,7 @@ Comments for partially supported 🟨 properties:
 | rotation         |      ✅       |
 | backgroundColor  |      🟨       |
 | clickable        |      ✅       |
+| zIndex           |      ✅       |
 
 Comments for partially supported 🟨 properties:
 
@@ -144,6 +145,8 @@ Comments for partially supported 🟨 properties:
 | hideInfoWindow       |      ✅       |
 | getIsInfoWindowShown |      🟨       |
 | remove               |      ✅       |
+| getZIndex            |      ✅       |
+| setZIndex            |      ✅       |
 
 Comments for partially supported 🟨 properties:
 

--- a/packages/plugin-googlemaps/src/main/java/com/openmobilehub/android/maps/plugin/googlemaps/extensions/OmhMarkerExtensions.kt
+++ b/packages/plugin-googlemaps/src/main/java/com/openmobilehub/android/maps/plugin/googlemaps/extensions/OmhMarkerExtensions.kt
@@ -58,5 +58,9 @@ internal fun OmhMarkerOptions.toMarkerOptions(logger: UnsupportedFeatureLogger =
         mappedOptions.icon(null)
     }
 
+    zIndex?.let {
+        mappedOptions.zIndex(it)
+    }
+
     return mappedOptions
 }

--- a/packages/plugin-googlemaps/src/main/java/com/openmobilehub/android/maps/plugin/googlemaps/presentation/maps/OmhMarkerImpl.kt
+++ b/packages/plugin-googlemaps/src/main/java/com/openmobilehub/android/maps/plugin/googlemaps/presentation/maps/OmhMarkerImpl.kt
@@ -181,4 +181,12 @@ internal class OmhMarkerImpl(
 
         marker.remove()
     }
+
+    override fun getZIndex(): Float {
+        return marker.zIndex
+    }
+
+    override fun setZIndex(zIndex: Float) {
+        marker.zIndex = zIndex
+    }
 }

--- a/packages/plugin-googlemaps/src/test/java/com/openmobilehub/android/maps/plugin/googlemaps/presentation/extensions/OmhMarkerOptionsTest.kt
+++ b/packages/plugin-googlemaps/src/test/java/com/openmobilehub/android/maps/plugin/googlemaps/presentation/extensions/OmhMarkerOptionsTest.kt
@@ -165,6 +165,26 @@ internal class OmhMarkerOptionsTest {
     }
 
     @Test
+    fun `toMarkerOptions should leave zIndex at default value when not passed`() {
+        // Act
+        val options = OmhMarkerOptions().toMarkerOptions(mockLogger)
+
+        // Assert
+        assertEquals(options.zIndex, 0f)
+    }
+
+    @Test
+    fun `toMarkerOptions should set zIndex when passed`() {
+        // Act
+        val options = OmhMarkerOptions().apply {
+            zIndex = 1f
+        }.toMarkerOptions(mockLogger)
+
+        // Assert
+        assertEquals(options.zIndex, 1f)
+    }
+
+    @Test
     fun `toMarkerOptions should return log setter not supported for backgroundColor property`() {
         OmhMarkerOptions().apply {
             backgroundColor = 0xFFFFFF

--- a/packages/plugin-googlemaps/src/test/java/com/openmobilehub/android/maps/plugin/googlemaps/presentation/maps/OmhMarkerImplTest.kt
+++ b/packages/plugin-googlemaps/src/test/java/com/openmobilehub/android/maps/plugin/googlemaps/presentation/maps/OmhMarkerImplTest.kt
@@ -291,4 +291,30 @@ class OmhMarkerImplTest {
         }
         assertEquals(marker.isInfoWindowShown, false)
     }
+
+    @Test
+    fun `getZIndex should return proper value`() {
+        // Arrange
+        val expected = 0.45f
+        every { marker.zIndex } returns expected
+
+        // Act
+        val actual = omhMarker.getZIndex()
+
+        // Assert
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `setZIndex should log setter not supported`() {
+        // Arrange
+        val expected = 0.45f
+        every { marker.zIndex = any() } just runs
+
+        // Act
+        omhMarker.setZIndex(expected)
+
+        // Assert
+        verify { marker.zIndex = expected }
+    }
 }

--- a/packages/plugin-mapbox/README.md
+++ b/packages/plugin-mapbox/README.md
@@ -91,6 +91,7 @@ Comments for partially supported 🟨 properties:
 | rotation         |      ✅       |
 | backgroundColor  |      ✅       |
 | clickable        |      ✅       |
+| zIndex           |      ❌       |
 
 Comments for partially supported 🟨 properties:
 
@@ -129,6 +130,8 @@ Comments for partially supported 🟨 properties:
 | hideInfoWindow       |      ✅       |
 | getIsInfoWindowShown |      ✅       |
 | remove               |      ✅       |
+| getZIndex            |      ❌       |
+| setZIndex            |      ❌       |
 
 Comments for partially supported 🟨 properties:
 

--- a/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/extensions/OmhMarkerExtensions.kt
+++ b/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/extensions/OmhMarkerExtensions.kt
@@ -18,12 +18,15 @@ package com.openmobilehub.android.maps.plugin.mapbox.extensions
 
 import com.mapbox.maps.extension.style.layers.generated.SymbolLayer
 import com.openmobilehub.android.maps.core.presentation.models.OmhMarkerOptions
+import com.openmobilehub.android.maps.core.utils.logging.UnsupportedFeatureLogger
 import com.openmobilehub.android.maps.plugin.mapbox.presentation.maps.OmhMarkerImpl
 import com.openmobilehub.android.maps.plugin.mapbox.utils.AnchorConverter
 import com.openmobilehub.android.maps.plugin.mapbox.utils.Constants
+import com.openmobilehub.android.maps.plugin.mapbox.utils.markerLogger
 
 internal fun OmhMarkerOptions.applyMarkerOptions(
-    markerSymbolLayer: SymbolLayer
+    markerSymbolLayer: SymbolLayer,
+    logger: UnsupportedFeatureLogger = markerLogger
 ) {
     // icon
     // iconImage(markerImageID) will be handled by setIcon
@@ -49,4 +52,9 @@ internal fun OmhMarkerOptions.applyMarkerOptions(
     // isFlat
     markerSymbolLayer.iconPitchAlignment(OmhMarkerImpl.getIconsPitchAlignment(isFlat))
     markerSymbolLayer.iconRotationAlignment(OmhMarkerImpl.getIconsRotationAlignment(isFlat))
+
+    // zIndex
+    zIndex?.let {
+        logger.logNotSupported("zIndex")
+    }
 }

--- a/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/OmhMarkerImpl.kt
+++ b/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/OmhMarkerImpl.kt
@@ -448,6 +448,15 @@ internal class OmhMarkerImpl(
         omhInfoWindow.remove()
     }
 
+    override fun getZIndex(): Float? {
+        logger.logGetterNotSupported("zIndex")
+        return null
+    }
+
+    override fun setZIndex(zIndex: Float) {
+        logger.logSetterNotSupported("zIndex")
+    }
+
     internal companion object {
         internal fun getIconsPitchAlignment(isFlat: Boolean): IconPitchAlignment {
             return if (isFlat) {

--- a/packages/plugin-mapbox/src/test/java/com/openmobilehub/android/maps/plugin/mapbox/extensions/OmhMarkerExtensionsTest.kt
+++ b/packages/plugin-mapbox/src/test/java/com/openmobilehub/android/maps/plugin/mapbox/extensions/OmhMarkerExtensionsTest.kt
@@ -41,6 +41,7 @@ import com.openmobilehub.android.maps.core.R
 import com.openmobilehub.android.maps.core.presentation.models.OmhCoordinate
 import com.openmobilehub.android.maps.core.presentation.models.OmhMarkerOptions
 import com.openmobilehub.android.maps.core.utils.DrawableConverter
+import com.openmobilehub.android.maps.core.utils.logging.UnsupportedFeatureLogger
 import com.openmobilehub.android.maps.core.utils.uuid.DefaultUUIDGenerator
 import com.openmobilehub.android.maps.plugin.mapbox.presentation.maps.OmhMapImpl
 import com.openmobilehub.android.maps.plugin.mapbox.presentation.maps.OmhMarkerImpl
@@ -73,6 +74,8 @@ internal class OmhMarkerExtensionsTest(
     private val mapView = mockk<MapView>()
     private val context = mockk<Context>()
     private val safeStyle = mockk<Style>(relaxed = true)
+    private val mockLogger: UnsupportedFeatureLogger =
+        mockk<UnsupportedFeatureLogger>(relaxed = true)
     private val defaultMarkerIconDrawable = mockk<Drawable>()
     private val convertDrawableToBitmapMock = mockk<Bitmap>()
     private lateinit var mockedViewDrawnToBitmap: Bitmap
@@ -98,6 +101,7 @@ internal class OmhMarkerExtensionsTest(
             position = omhCoordinate
             title = "Marker Title 1"
             isVisible = false
+            zIndex = 1.0f
         }
 
         @JvmStatic
@@ -166,7 +170,7 @@ internal class OmhMarkerExtensionsTest(
         val markerLayer =
             symbolLayer(OmhMarkerImpl.getSymbolLayerID(markerUUID), markerGeoJsonSourceID) {}
 
-        options.applyMarkerOptions(markerLayer)
+        options.applyMarkerOptions(markerLayer, mockLogger)
 
         val omhMarker = OmhMarkerImpl(
             markerUUID = markerUUID,
@@ -500,6 +504,21 @@ internal class OmhMarkerExtensionsTest(
 
             safeStyle.addLayer(markerIconLayer)
             safeStyle.addLayer(infoWindowLayer)
+        }
+    }
+
+    @Test
+    fun `OmhMarkerOptions should log zIndex not supported when using zIndex`() {
+        // Act
+        createMarker(
+            mapView.context,
+            markerUUID,
+            data
+        )
+
+        // Assert
+        if (data.zIndex != null) {
+            verify { mockLogger.logNotSupported("zIndex") }
         }
     }
 }

--- a/packages/plugin-mapbox/src/test/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/OmhMarkerImplTest.kt
+++ b/packages/plugin-mapbox/src/test/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/OmhMarkerImplTest.kt
@@ -32,6 +32,7 @@ import io.mockk.runs
 import io.mockk.unmockkAll
 import io.mockk.verify
 import org.junit.AfterClass
+import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -369,6 +370,28 @@ class OmhMarkerImplTest {
             omhMarker.omhInfoWindow.remove()
         }
         assertEquals(omhMarker.getIsInfoWindowShown(), false)
+    }
+
+    @Test
+    fun `getZIndex should return null and log getter not supported`() {
+        // Act
+        val result = omhMarker.getZIndex()
+
+        // Assert
+        Assert.assertNull(result)
+        verify { logger.logGetterNotSupported("zIndex") }
+    }
+
+    @Test
+    fun `setZIndex should log setter not supported`() {
+        // Arrange
+        val zIndex = 1.0f
+
+        // Act
+        omhMarker.setZIndex(zIndex)
+
+        // Assert
+        verify { logger.logSetterNotSupported("zIndex") }
     }
 
     companion object {

--- a/packages/plugin-openstreetmap/README.md
+++ b/packages/plugin-openstreetmap/README.md
@@ -97,6 +97,7 @@ Comments for partially supported 🟨 properties:
 | rotation         |      ✅       |
 | backgroundColor  |      ❌       |
 | clickable        |      ✅       |
+| zIndex           |      ❌       |
 
 #### OmhMarker
 
@@ -129,6 +130,8 @@ Comments for partially supported 🟨 properties:
 | hideInfoWindow       |      ✅       |
 | getIsInfoWindowShown |      ✅       |
 | remove               |      ✅       |
+| getZIndex            |      ❌       |
+| setZIndex            |      ❌       |
 
 ### Polyline
 

--- a/packages/plugin-openstreetmap/src/main/java/com/openmobilehub/android/maps/plugin/openstreetmap/extensions/OmhMarkerExtensions.kt
+++ b/packages/plugin-openstreetmap/src/main/java/com/openmobilehub/android/maps/plugin/openstreetmap/extensions/OmhMarkerExtensions.kt
@@ -60,5 +60,9 @@ internal fun OmhMarkerOptions.toMarkerOptions(
         marker.setDefaultIcon()
     }
 
+    zIndex?.let {
+        logger.logNotSupported("zIndex")
+    }
+
     return marker
 }

--- a/packages/plugin-openstreetmap/src/main/java/com/openmobilehub/android/maps/plugin/openstreetmap/presentation/maps/OmhMarkerImpl.kt
+++ b/packages/plugin-openstreetmap/src/main/java/com/openmobilehub/android/maps/plugin/openstreetmap/presentation/maps/OmhMarkerImpl.kt
@@ -191,4 +191,13 @@ internal class OmhMarkerImpl(
 
         mapView.invalidate()
     }
+
+    override fun getZIndex(): Float? {
+        logger.logGetterNotSupported("zIndex")
+        return null
+    }
+
+    override fun setZIndex(zIndex: Float) {
+        logger.logSetterNotSupported("zIndex")
+    }
 }

--- a/packages/plugin-openstreetmap/src/test/java/com/openmobilehub/android/maps/plugin/openstreetmap/extensions/OmhMarkerOptionsExtensionTest.kt
+++ b/packages/plugin-openstreetmap/src/test/java/com/openmobilehub/android/maps/plugin/openstreetmap/extensions/OmhMarkerOptionsExtensionTest.kt
@@ -136,7 +136,7 @@ internal class OmhMarkerOptionsExtensionTest {
     }
 
     @Test
-    fun `toMarkerOptions has proper default constructor arguments`() {
+    fun `OmhMarkerOptions has proper default constructor arguments`() {
         val defaultOmhMarkerOptions = OmhMarkerOptions()
 
         assertEquals(defaultOmhMarkerOptions.draggable, false)
@@ -162,5 +162,16 @@ internal class OmhMarkerOptionsExtensionTest {
         assertEquals(defaultOmhMarkerOptions.backgroundColor, null)
         assertEquals(defaultOmhMarkerOptions.icon, null)
         assertEquals(defaultOmhMarkerOptions.clickable, true)
+    }
+
+    @Test
+    fun `toMarkerOptions should log zIndex not supported when using zIndex`() {
+        // Act
+        OmhMarkerOptions().apply {
+            zIndex = 1.0f
+        }.toMarkerOptions(omhMap, mapView, mockLogger)
+
+        // Assert
+        verify { mockLogger.logNotSupported("zIndex") }
     }
 }

--- a/packages/plugin-openstreetmap/src/test/java/com/openmobilehub/android/maps/plugin/openstreetmap/presentation/maps/OmhMarkerImplTest.kt
+++ b/packages/plugin-openstreetmap/src/test/java/com/openmobilehub/android/maps/plugin/openstreetmap/presentation/maps/OmhMarkerImplTest.kt
@@ -22,6 +22,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -291,5 +292,27 @@ class OmhMarkerImplTest {
             mockMapView.invalidate()
         }
         assertEquals(marker.isInfoWindowShown, false)
+    }
+
+    @Test
+    fun `getZIndex should return null and log getter not supported`() {
+        // Act
+        val result = omhMarker.getZIndex()
+
+        // Assert
+        Assert.assertNull(result)
+        verify { mockLogger.logGetterNotSupported("zIndex") }
+    }
+
+    @Test
+    fun `setZIndex should log setter not supported`() {
+        // Arrange
+        val zIndex = 1.0f
+
+        // Act
+        omhMarker.setZIndex(zIndex)
+
+        // Assert
+        verify { mockLogger.logSetterNotSupported("zIndex") }
     }
 }


### PR DESCRIPTION
## Summary

This PR brings support for z-index to the marker by bringing:
- `zIndex` property to `OmhMarkerOptions`
- `getZIndex` & `setZIndex` to `OmhMarker`

From the current providers, only GMaps support this.

## Demo

https://github.com/openmobilehub/android-omh-maps/assets/10586109/fc6e2678-63cb-46c4-b50e-cee90066bf96


## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-279](https://callstackio.atlassian.net/browse/OMHD-279)
