### PR TITLE
feat: extend OmhMap interface

### DIFF
--- a/apps/maps-sample/src/main/java/com/openmobilehub/android/maps/sample/maps/MapStylesFragment.kt
+++ b/apps/maps-sample/src/main/java/com/openmobilehub/android/maps/sample/maps/MapStylesFragment.kt
@@ -110,7 +110,7 @@ class MapStylesFragment : Fragment(), OmhOnMapReadyCallback {
             val providerMapStyles =
                 mapStyles[omhMap?.providerName] ?: return@OnCheckedChangeListener
             when (checkedId) {
-                R.id.style_none -> omhMap?.setMapStyle(null)
+                R.id.style_none -> omhMap?.setMapStyle(json = null)
                 R.id.style_retro -> omhMap?.setMapStyle(providerMapStyles.retro)
                 R.id.style_dark -> omhMap?.setMapStyle(providerMapStyles.dark)
                 R.id.style_silver -> omhMap?.setMapStyle(providerMapStyles.silver)

--- a/packages/core/src/main/java/com/openmobilehub/android/maps/core/presentation/interfaces/maps/OmhMap.kt
+++ b/packages/core/src/main/java/com/openmobilehub/android/maps/core/presentation/interfaces/maps/OmhMap.kt
@@ -202,6 +202,15 @@ interface OmhMap {
     fun setMapStyle(json: Int?)
 
     /**
+     * Sets the style of the map based on a provided string.
+     * The string should define the styles for the map elements.
+     *
+     * @param jsonString The string defining the map styles.
+     * If null, the map style will be reset to the default style.
+     */
+    fun setMapStyle(jsonString: String?)
+
+    /**
      * Updates the scale factor of the map.
      * The scale factor is used to adjust the size of the map elements, e.g. polylines width.
      * Might be useful when the app uses multiple map providers and the map elements should have the same

--- a/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMapImpl.kt
+++ b/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMapImpl.kt
@@ -229,6 +229,10 @@ internal class OmhMapImpl(
         logger.logSetterNotSupported("mapStyle")
     }
 
+    override fun setMapStyle(jsonString: String?) {
+        logger.logSetterNotSupported("mapStyle")
+    }
+
     override fun setScaleFactor(scaleFactor: Float) {
         _scaleFactor = scaleFactor
     }

--- a/packages/plugin-azuremaps/src/test/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMapImplTest.kt
+++ b/packages/plugin-azuremaps/src/test/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMapImplTest.kt
@@ -185,9 +185,21 @@ class OmhMapImplTest {
     }
 
     @Test
-    fun `setMapStyle calls logger logSetterNotSupported`() {
+    fun `setMapStyle (json) calls logger logSetterNotSupported`() {
         // Arrange
         val mapStyle = 0
+
+        // Act
+        omhMapImpl.setMapStyle(mapStyle)
+
+        // Assert
+        verify { logger.logSetterNotSupported("mapStyle") }
+    }
+
+    @Test
+    fun `setMapStyle (jsonString) calls logger logSetterNotSupported`() {
+        // Arrange
+        val mapStyle = ""
 
         // Act
         omhMapImpl.setMapStyle(mapStyle)

--- a/packages/plugin-googlemaps/src/main/java/com/openmobilehub/android/maps/plugin/googlemaps/presentation/maps/OmhMapImpl.kt
+++ b/packages/plugin-googlemaps/src/main/java/com/openmobilehub/android/maps/plugin/googlemaps/presentation/maps/OmhMapImpl.kt
@@ -280,8 +280,22 @@ class OmhMapImpl(
             googleMap.setMapStyle(null)
             return
         }
+
+        applyMapStyle(MapStyleOptions.loadRawResourceStyle(context, json))
+    }
+
+    override fun setMapStyle(jsonString: String?) {
+        if (jsonString == null) {
+            googleMap.setMapStyle(null)
+            return
+        }
+
+        applyMapStyle(MapStyleOptions(jsonString))
+    }
+
+    private fun applyMapStyle(mapStyleOptions: MapStyleOptions) {
         val isStyleApplied =
-            googleMap.setMapStyle(MapStyleOptions.loadRawResourceStyle(context, json))
+            googleMap.setMapStyle(mapStyleOptions)
         if (!isStyleApplied) {
             logger.logWarning("Failed to apply custom map style. Check logs from Google Maps SDK.")
         }

--- a/packages/plugin-googlemaps/src/test/java/com/openmobilehub/android/maps/plugin/googlemaps/presentation/maps/OmhMapImplTest.kt
+++ b/packages/plugin-googlemaps/src/test/java/com/openmobilehub/android/maps/plugin/googlemaps/presentation/maps/OmhMapImplTest.kt
@@ -133,7 +133,7 @@ class OmhMapImplTest {
     }
 
     @Test
-    fun `setMapStyle applies custom style when JSON resource ID provided`() {
+    fun `setMapStyle (json) applies custom style when JSON resource ID provided`() {
         // Arrange
         val jsonStyleResId = 1
 
@@ -150,7 +150,7 @@ class OmhMapImplTest {
     }
 
     @Test
-    fun `setMapStyle logs warning message when style is not applied`() {
+    fun `setMapStyle (json) logs warning message when style is not applied`() {
         // Arrange
         val jsonStyleResId = 1
 
@@ -167,12 +167,50 @@ class OmhMapImplTest {
     }
 
     @Test
-    fun `setMapStyle sets default style when null JSON resource ID provided`() {
+    fun `setMapStyle (json) sets default style when null JSON resource ID provided`() {
         // Arrange
         every { googleMap.setMapStyle(any()) } returns true
 
         // Act
-        omhMapImpl.setMapStyle(null)
+        omhMapImpl.setMapStyle(json = null)
+
+        // Assert
+        verify { googleMap.setMapStyle(null) }
+    }
+
+    @Test
+    fun `setMapStyle (jsonString) applies custom style when json string provided`() {
+        // Arrange
+        val jsonStyleString = "{}"
+        every { googleMap.setMapStyle(any()) } returns true
+
+        // Act
+        omhMapImpl.setMapStyle(jsonStyleString)
+
+        // Assert
+        verify { googleMap.setMapStyle(any<MapStyleOptions>()) }
+    }
+
+    @Test
+    fun `setMapStyle (jsonString) logs warning message when style is not applied`() {
+        // Arrange
+        val jsonStyleString = "{}"
+        every { googleMap.setMapStyle(any()) } returns false
+
+        // Act
+        omhMapImpl.setMapStyle(jsonStyleString)
+
+        // Assert
+        verify { logger.logWarning("Failed to apply custom map style. Check logs from Google Maps SDK.") }
+    }
+
+    @Test
+    fun `setMapStyle (jsonString) sets default style when null provided`() {
+        // Arrange
+        every { googleMap.setMapStyle(any()) } returns true
+
+        // Act
+        omhMapImpl.setMapStyle(jsonString = null)
 
         // Assert
         verify { googleMap.setMapStyle(null) }

--- a/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/OmhMapImpl.kt
+++ b/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/OmhMapImpl.kt
@@ -420,15 +420,28 @@ class OmhMapImpl(
 
         val styleJSONString = JSONUtil.convertJSONToString(context, json, logger)
 
+        applyMapStyle(styleJSONString)
+    }
+
+    override fun setMapStyle(jsonString: String?) {
+        if (jsonString == null) {
+            mapView.mapboxMap.loadStyle(Style.STANDARD)
+            return
+        }
+
+        applyMapStyle(jsonString)
+    }
+
+    private fun applyMapStyle(jsonString: String?) {
         val onStyleLoadedCallback = { style: Style ->
             if (!style.isValid()) {
                 logger.logWarning("Failed to apply custom map style. Check logs from Mapbox SDK.")
             }
         }
 
-        styleJSONString?.let { jsonString ->
-            mapView.mapboxMap.loadStyle(jsonString, onStyleLoadedCallback)
-        } ?: logger.logError("Failed to load style from resource with id: $json")
+        jsonString?.let { safeJsonString ->
+            mapView.mapboxMap.loadStyle(safeJsonString, onStyleLoadedCallback)
+        } ?: logger.logError("Failed to load map style. Style string is null.")
     }
 
     override fun setScaleFactor(scaleFactor: Float) {

--- a/packages/plugin-openstreetmap/src/main/java/com/openmobilehub/android/maps/plugin/openstreetmap/presentation/maps/OmhMapImpl.kt
+++ b/packages/plugin-openstreetmap/src/main/java/com/openmobilehub/android/maps/plugin/openstreetmap/presentation/maps/OmhMapImpl.kt
@@ -391,7 +391,11 @@ class OmhMapImpl(
     }
 
     override fun setMapStyle(json: Int?) {
-        // To be implemented
+        logger.logSetterNotSupported("mapStyle")
+    }
+
+    override fun setMapStyle(jsonString: String?) {
+        logger.logSetterNotSupported("mapStyle")
     }
 
     override fun setScaleFactor(scaleFactor: Float) {


### PR DESCRIPTION
## Summary
This PR extends interface of `OmhMap` with `setMapStyle(jsonString)` method. It's required mostly for RN integration.

## Demo

N/A

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests
