### PR TITLE
feat: added demo app contentDescription tags for E2E testing selectors

### DIFF
--- a/apps/maps-sample/src/main/res/layout/fragment_location_picker_map.xml
+++ b/apps/maps-sample/src/main/res/layout/fragment_location_picker_map.xml
@@ -117,6 +117,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:checked="true"
+                android:contentDescription="@string/my_location_enabled"
                 android:text="@string/my_location_enabled" />
 
         </LinearLayout>

--- a/apps/maps-sample/src/main/res/layout/fragment_location_result.xml
+++ b/apps/maps-sample/src/main/res/layout/fragment_location_result.xml
@@ -19,6 +19,7 @@
         android:id="@+id/button_share_location"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:contentDescription="@string/share_location"
         android:text="@string/share_location"
         android:textAlignment="center"
         tools:visibility="visible" />

--- a/apps/maps-sample/src/main/res/layout/fragment_map_camera.xml
+++ b/apps/maps-sample/src/main/res/layout/fragment_map_camera.xml
@@ -41,6 +41,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:checked="true"
+                android:contentDescription="@string/zoom_gestures"
                 android:text="@string/zoom_gestures" />
 
             <CheckBox
@@ -48,30 +49,35 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:checked="true"
+                android:contentDescription="@string/rotate_gestures"
                 android:text="@string/rotate_gestures" />
 
             <Button
                 android:id="@+id/button_showCameraPositionCoordinate"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:contentDescription="@string/show_camera_position_coordinate"
                 android:text="@string/show_camera_position_coordinate" />
 
             <Button
                 android:id="@+id/button_moveMapToEverest"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:contentDescription="@string/move_map_to_everest"
                 android:text="@string/move_map_to_everest" />
 
             <Button
                 android:id="@+id/button_moveMapSahara"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:contentDescription="@string/move_map_to_sahara"
                 android:text="@string/move_map_to_sahara" />
 
             <Button
                 android:id="@+id/button_makeSnapshot"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:contentDescription="@string/make_snapshot"
                 android:text="@string/make_snapshot" />
 
         </LinearLayout>

--- a/apps/maps-sample/src/main/res/layout/fragment_map_info_windows.xml
+++ b/apps/maps-sample/src/main/res/layout/fragment_map_info_windows.xml
@@ -65,6 +65,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:checked="true"
+                android:contentDescription="@string/snippet"
                 android:text="@string/snippet" />
 
             <com.openmobilehub.android.maps.sample.customviews.PanelSeekbar
@@ -73,6 +74,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/anchorIWU"
                 app:maxValue="100"
                 app:minValue="0"
                 app:titleText="@string/anchorIWU" />
@@ -83,6 +85,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/anchorIWV"
                 app:maxValue="100"
                 app:minValue="0"
                 app:titleText="@string/anchorIWV" />
@@ -93,6 +96,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/appearance"
                 app:titleText="@string/appearance" />
 
             <com.google.android.material.divider.MaterialDivider
@@ -113,6 +117,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:checked="true"
+                android:contentDescription="@string/window_should_rerender_on_drag"
                 android:text="@string/window_should_rerender_on_drag" />
 
             <CheckBox
@@ -120,6 +125,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:checked="true"
+                android:contentDescription="@string/window_should_toggle_on_marker_click"
                 android:text="@string/window_should_toggle_on_marker_click" />
 
             <CheckBox
@@ -127,6 +133,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:checked="true"
+                android:contentDescription="@string/window_should_hide_on_click"
                 android:text="@string/window_should_hide_on_click" />
 
             <com.google.android.material.divider.MaterialDivider
@@ -138,6 +145,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
                 android:layout_marginBottom="10dp"
+                android:contentDescription="@string/label_imperative_usage"
                 android:gravity="center"
                 android:text="@string/label_imperative_usage"
                 android:textSize="18sp" />
@@ -146,12 +154,14 @@
                 android:id="@+id/button_openInfoWindow"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:contentDescription="@string/open_info_window"
                 android:text="@string/open_info_window" />
 
             <Button
                 android:id="@+id/button_hideInfoWindow"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:contentDescription="@string/hide_info_window"
                 android:text="@string/hide_info_window" />
 
             <com.google.android.material.divider.MaterialDivider
@@ -172,6 +182,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:checked="true"
+                android:contentDescription="@string/visible"
                 android:text="@string/visible" />
 
             <CheckBox
@@ -179,6 +190,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:checked="true"
+                android:contentDescription="@string/clickable"
                 android:text="@string/clickable" />
 
             <com.openmobilehub.android.maps.sample.customviews.PanelSeekbar
@@ -187,6 +199,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/rotation"
                 app:maxValue="360"
                 app:minValue="0"
                 app:titleText="@string/rotation" />
@@ -197,6 +210,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/anchorU"
                 app:maxValue="100"
                 app:minValue="0"
                 app:titleText="@string/anchorU" />
@@ -207,6 +221,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/anchorV"
                 app:maxValue="100"
                 app:minValue="0"
                 app:titleText="@string/anchorV" />

--- a/apps/maps-sample/src/main/res/layout/fragment_map_markers.xml
+++ b/apps/maps-sample/src/main/res/layout/fragment_map_markers.xml
@@ -64,6 +64,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:checked="true"
+                android:contentDescription="@string/visible"
                 android:text="@string/visible" />
 
             <CheckBox
@@ -71,6 +72,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:checked="true"
+                android:contentDescription="@string/flat"
                 android:text="@string/flat" />
 
             <CheckBox
@@ -78,6 +80,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:checked="true"
+                android:contentDescription="@string/clickable"
                 android:text="@string/clickable" />
 
             <CheckBox
@@ -85,6 +88,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:checked="true"
+                android:contentDescription="@string/draggable"
                 android:text="@string/draggable" />
 
             <CheckBox
@@ -92,6 +96,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:checked="true"
+                android:contentDescription="@string/snippet"
                 android:text="@string/snippet" />
 
             <com.openmobilehub.android.maps.sample.customviews.PanelSeekbar
@@ -100,6 +105,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/rotation"
                 app:maxValue="360"
                 app:minValue="0"
                 app:titleText="@string/rotation" />
@@ -110,6 +116,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/anchorU"
                 app:maxValue="100"
                 app:minValue="0"
                 app:titleText="@string/anchorU" />
@@ -120,6 +127,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/anchorV"
                 app:maxValue="100"
                 app:minValue="0"
                 app:titleText="@string/anchorV" />
@@ -130,6 +138,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/alpha"
                 app:maxValue="100"
                 app:minValue="0"
                 app:titleText="@string/alpha" />
@@ -140,6 +149,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/appearance"
                 app:titleText="@string/appearance" />
 
             <com.openmobilehub.android.maps.sample.customviews.PanelColorSeekbar
@@ -148,6 +158,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/color"
                 app:titleText="@string/color" />
 
             <com.openmobilehub.android.maps.sample.customviews.PanelSeekbar
@@ -156,6 +167,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/z_index"
                 app:maxValue="5"
                 app:minValue="0"
                 app:titleText="@string/z_index" />
@@ -165,6 +177,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
                 android:layout_marginBottom="10dp"
+                android:contentDescription="@string/label_demo_behaviour"
                 android:gravity="center"
                 android:text="@string/label_demo_behaviour"
                 android:textSize="18sp" />
@@ -174,6 +187,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:checked="true"
+                android:contentDescription="@string/remove_marker_on_click"
                 android:text="@string/remove_marker_on_click" />
 
             <Button
@@ -181,6 +195,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_marginBottom="80dp"
+                android:contentDescription="@string/label_demo_button_restore_customizable_marker"
                 android:text="@string/label_demo_button_restore_customizable_marker" />
         </LinearLayout>
     </ScrollView>

--- a/apps/maps-sample/src/main/res/layout/fragment_map_polygons.xml
+++ b/apps/maps-sample/src/main/res/layout/fragment_map_polygons.xml
@@ -40,6 +40,7 @@
                 android:id="@+id/button_randomizeOutline"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:contentDescription="@string/randomize_outline"
                 android:text="@string/randomize_outline" />
 
             <CheckBox
@@ -47,6 +48,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
+                android:contentDescription="@string/show_reference_polygon"
                 android:text="@string/show_reference_polygon" />
 
             <CheckBox
@@ -54,18 +56,21 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:checked="true"
+                android:contentDescription="@string/visible"
                 android:text="@string/visible" />
 
             <CheckBox
                 android:id="@+id/checkBox_isClickable"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:contentDescription="@string/clickable"
                 android:text="@string/clickable" />
 
             <CheckBox
                 android:id="@+id/checkBox_withHoles"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:contentDescription="@string/holes"
                 android:text="@string/holes" />
 
             <com.openmobilehub.android.maps.sample.customviews.PanelSeekbar
@@ -74,6 +79,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/stroke_width"
                 app:maxValue="100"
                 app:minValue="1"
                 app:titleText="@string/stroke_width" />
@@ -84,6 +90,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/stroke_color"
                 app:titleText="@string/stroke_color" />
 
             <com.openmobilehub.android.maps.sample.customviews.PanelColorSeekbar
@@ -92,6 +99,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/fill_color"
                 app:titleText="@string/fill_color" />
 
             <com.openmobilehub.android.maps.sample.customviews.PanelSpinner
@@ -100,6 +108,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/stroke_join_type"
                 app:titleText="@string/stroke_join_type" />
 
             <com.openmobilehub.android.maps.sample.customviews.PanelSpinner
@@ -108,6 +117,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/stroke_pattern"
                 app:titleText="@string/stroke_pattern" />
 
             <com.openmobilehub.android.maps.sample.customviews.PanelSeekbar
@@ -116,6 +126,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/z_index"
                 app:maxValue="100"
                 app:minValue="1"
                 app:titleText="@string/z_index" />

--- a/apps/maps-sample/src/main/res/layout/fragment_map_polylines.xml
+++ b/apps/maps-sample/src/main/res/layout/fragment_map_polylines.xml
@@ -40,6 +40,7 @@
                 android:id="@+id/button_randomizePoints"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:contentDescription="@string/randomize_points"
                 android:text="@string/randomize_points" />
 
             <CheckBox
@@ -47,6 +48,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
+                android:contentDescription="@string/show_reference_polyline"
                 android:text="@string/show_reference_polyline" />
 
             <CheckBox
@@ -54,6 +56,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:checked="true"
+                android:contentDescription="@string/visible"
                 android:padding="0dp"
                 android:text="@string/visible" />
 
@@ -61,6 +64,7 @@
                 android:id="@+id/checkBox_isClickable"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:contentDescription="@string/clickable"
                 android:text="@string/clickable" />
 
             <com.openmobilehub.android.maps.sample.customviews.PanelSeekbar
@@ -69,6 +73,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/width"
                 app:maxValue="100"
                 app:minValue="1"
                 app:titleText="@string/width" />
@@ -79,12 +84,14 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/color"
                 app:titleText="@string/color" />
 
             <com.openmobilehub.android.maps.sample.customviews.PanelSpinner
                 android:id="@+id/panelSpinner_cap"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:contentDescription="@string/cap"
                 app:titleText="@string/cap" />
 
             <com.openmobilehub.android.maps.sample.customviews.PanelSpinner
@@ -93,6 +100,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/start_cap"
                 app:titleText="@string/start_cap" />
 
             <com.openmobilehub.android.maps.sample.customviews.PanelSpinner
@@ -101,6 +109,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/end_cap"
                 app:titleText="@string/end_cap" />
 
             <com.openmobilehub.android.maps.sample.customviews.PanelSpinner
@@ -109,6 +118,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/join_type"
                 app:titleText="@string/join_type" />
 
             <com.openmobilehub.android.maps.sample.customviews.PanelSpinner
@@ -117,6 +127,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/pattern"
                 app:titleText="@string/pattern" />
 
             <com.openmobilehub.android.maps.sample.customviews.PanelSeekbar
@@ -125,6 +136,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
                 android:layout_marginBottom="15dp"
+                android:contentDescription="@string/z_index"
                 app:maxValue="100"
                 app:minValue="1"
                 app:titleText="@string/z_index" />
@@ -134,6 +146,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="15dp"
+                android:contentDescription="@string/span"
                 android:text="@string/span" />
 
             <LinearLayout
@@ -149,6 +162,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="15dp"
                     android:layout_marginBottom="15dp"
+                    android:contentDescription="@string/segments"
                     app:maxValue="7"
                     app:minValue="1"
                     app:titleText="@string/segments" />
@@ -159,6 +173,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="15dp"
                     android:layout_marginBottom="15dp"
+                    android:contentDescription="@string/span_color"
                     app:titleText="@string/span_color" />
 
                 <CheckBox
@@ -166,6 +181,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="15dp"
+                    android:contentDescription="@string/gradient"
                     android:text="@string/gradient" />
 
                 <LinearLayout
@@ -179,6 +195,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginBottom="15dp"
+                        android:contentDescription="@string/from_color"
                         app:titleText="@string/from_color" />
 
                     <com.openmobilehub.android.maps.sample.customviews.PanelColorSeekbar
@@ -187,6 +204,7 @@
                         android:layout_height="wrap_content"
                         android:layout_marginTop="15dp"
                         android:layout_marginBottom="15dp"
+                        android:contentDescription="@string/to_color"
                         app:titleText="@string/to_color" />
                 </LinearLayout>
 
@@ -195,6 +213,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="15dp"
+                    android:contentDescription="@string/span_pattern"
                     android:text="@string/span_pattern" />
 
             </LinearLayout>

--- a/apps/maps-sample/src/main/res/layout/fragment_map_styles.xml
+++ b/apps/maps-sample/src/main/res/layout/fragment_map_styles.xml
@@ -47,31 +47,36 @@
                 android:id="@+id/radioGroup_styles"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:checkedButton="@id/style_none">
+                android:checkedButton="@id/style_none"
+                android:contentDescription="@string/map_style_radio_group_title"
+                android:orientation="vertical">
 
                 <RadioButton
                     android:id="@+id/style_none"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:contentDescription="@string/none"
                     android:text="@string/none" />
 
                 <RadioButton
                     android:id="@+id/style_dark"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:contentDescription="@string/dark"
                     android:text="@string/dark" />
 
                 <RadioButton
                     android:id="@+id/style_retro"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:contentDescription="@string/retro"
                     android:text="@string/retro" />
 
                 <RadioButton
                     android:id="@+id/style_silver"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:contentDescription="@string/silver"
                     android:text="@string/silver" />
             </RadioGroup>
 

--- a/apps/maps-sample/src/main/res/layout/fragment_menu.xml
+++ b/apps/maps-sample/src/main/res/layout/fragment_menu.xml
@@ -29,6 +29,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
+            android:contentDescription="@string/provider"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/label_provider"
             app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
## Summary

This PR adds `android:contentDescription` attributes to demo control elements to be used as selectors for end-to-end testing with Appium.

## Demo

N/A

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-208](https://callstackio.atlassian.net/browse/OMHD-208)
