### PR TITLE
fix: marker icons display in specific scenarios in Azuremaps and Mapbox providers, adjust OSM provider to new icon loading system

### DIFF
--- a/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMarkerImpl.kt
+++ b/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMarkerImpl.kt
@@ -326,7 +326,7 @@ internal class OmhMarkerImpl(
         val markerImageID = getMarkerIconID(icon != null)
 
         // ensure the other custom icon is removed for memory optimization (if present)
-        if (lastMarkerIconID != null) mapViewDelegate.removeImage(lastMarkerIconID!!)
+        lastMarkerIconID?.let { mapViewDelegate.removeImage(it) }
 
         val bitmap = DrawableConverter.convertDrawableToBitmap(icon ?: getDefaultIcon())
 

--- a/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMarkerImpl.kt
+++ b/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMarkerImpl.kt
@@ -87,7 +87,7 @@ internal class OmhMarkerImpl(
             omhMarker = this,
         )
 
-        setIcon(initialIcon)
+        setIcon(initialIcon, backgroundColor)
     }
 
     override fun getPosition(): OmhCoordinate {
@@ -215,14 +215,19 @@ internal class OmhMarkerImpl(
         omhInfoWindow.setSnippet(snippet)
     }
 
-    override fun setIcon(icon: Drawable?) {
+    private fun setIcon(icon: Drawable?, color: Int?) {
         isCustomIconSet = icon != null
+        backgroundColor = color
 
         val addedIconID = addOrUpdateMarkerIconImage(icon)
         // color the icon image using Mapbox's SDF implementation
         markerSymbolLayer.setOptions(
             SymbolLayerOptions.iconImage(addedIconID)
         )
+    }
+
+    override fun setIcon(icon: Drawable?) {
+        setIcon(icon, null)
     }
 
     override fun getIsVisible(): Boolean {
@@ -274,11 +279,9 @@ internal class OmhMarkerImpl(
     }
 
     override fun setBackgroundColor(color: Int?) {
-        backgroundColor = color
-
         // set the default icon, also setting isCustomIconSet to keep track
         // of current state for rebuilding the icon
-        setIcon(null)
+        setIcon(null, color)
     }
 
     override fun showInfoWindow() {

--- a/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMarkerImpl.kt
+++ b/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMarkerImpl.kt
@@ -75,6 +75,8 @@ internal class OmhMarkerImpl(
     internal var iconWidth: Int = 0
     internal var iconHeight: Int = 0
 
+    private var lastMarkerIconID: String? = null
+
     init {
         isCustomIconSet = initialIcon != null
 
@@ -324,7 +326,7 @@ internal class OmhMarkerImpl(
         val markerImageID = getMarkerIconID(icon != null)
 
         // ensure the other custom icon is removed for memory optimization (if present)
-        mapViewDelegate.removeImage(getMarkerIconID(!isCustomIconSet))
+        if (lastMarkerIconID != null) mapViewDelegate.removeImage(lastMarkerIconID!!)
 
         val bitmap = DrawableConverter.convertDrawableToBitmap(icon ?: getDefaultIcon())
 
@@ -350,6 +352,8 @@ internal class OmhMarkerImpl(
             markerImageID,
             bitmap
         )
+
+        lastMarkerIconID = markerImageID
 
         return markerImageID
     }

--- a/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/OmhMarkerImpl.kt
+++ b/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/OmhMarkerImpl.kt
@@ -408,7 +408,7 @@ internal class OmhMarkerImpl(
         val markerImageID = getMarkerIconID(icon != null)
 
         // ensure the old icon is removed for memory optimization
-        if (lastMarkerIconID != null) style.removeStyleImage(lastMarkerIconID!!)
+        lastMarkerIconID?.let { style.removeStyleImage(it) }
 
         val bitmap = DrawableConverter.convertDrawableToBitmap(icon ?: getDefaultIcon())
 
@@ -448,8 +448,8 @@ internal class OmhMarkerImpl(
                 throw IllegalStateException("Failed to remove GeoJsonSource from map: $error")
             }
 
-            if (lastMarkerIconID != null) {
-                val removeImageResult = style.removeStyleImage(lastMarkerIconID!!)
+            lastMarkerIconID?.let {
+                val removeImageResult = style.removeStyleImage(it)
                 removeImageResult.error?.let { error ->
                     throw IllegalStateException("Failed to remove image from map: $error")
                 }

--- a/packages/plugin-mapbox/src/test/java/com/openmobilehub/android/maps/plugin/mapbox/extensions/OmhMarkerExtensionsTest.kt
+++ b/packages/plugin-mapbox/src/test/java/com/openmobilehub/android/maps/plugin/mapbox/extensions/OmhMarkerExtensionsTest.kt
@@ -346,11 +346,16 @@ internal class OmhMarkerExtensionsTest(
         // mock (on the new OmhMarker instance) that the map style had been loaded
         omhMarker.onStyleLoaded(safeStyle)
 
+        val previousMarkerIconId = omhMarker.lastMarkerIconID
+
+        omhMarker.setIcon(someOtherMockedDrawable)
+
         // here we check if marker properties are valid & set properly on the layer after map style is loaded
         verify {
             markerIconLayer.iconIgnorePlacement(true) // defaults from OmhMarkerExtensions
             markerIconLayer.iconAllowOverlap(true) // defaults from OmhMarkerExtensions
-            markerIconLayer.iconImage(omhMarker.getMarkerIconID(data.icon !== null))
+            markerIconLayer.iconImage(previousMarkerIconId!!)
+            markerIconLayer.iconImage(omhMarker.lastMarkerIconID!!)
             markerIconLayer.iconOpacity(data.alpha.toDouble())
             markerIconLayer.iconPitchAlignment(
                 OmhMarkerImpl.getIconsPitchAlignment(data.isFlat)
@@ -376,12 +381,18 @@ internal class OmhMarkerExtensionsTest(
         verify {
             // ensure that the previous icon (from the in-between scenario) has been
             // deleted from the layer to free allocated memory
-            safeStyle.removeStyleImage(omhMarker.getMarkerIconID(data.icon === null))
-            // ensure that the new icon has been added to the layer
+            safeStyle.removeStyleImage(previousMarkerIconId!!)
+            // ensure that the previous icon has once been added to the layer
             safeStyle.addImage(
-                omhMarker.getMarkerIconID(data.icon !== null),
+                previousMarkerIconId,
                 convertDrawableToBitmapMock,
                 data.icon === null // ensure SDF coloring is only enabled for the default icon
+            )
+            // ensure that the new icon has been added to the layer
+            safeStyle.addImage(
+                omhMarker.lastMarkerIconID!!,
+                convertDrawableToBitmapMock,
+                false // ensure SDF coloring is only enabled for the default icon
             )
         }
     }

--- a/packages/plugin-mapbox/src/test/java/com/openmobilehub/android/maps/plugin/mapbox/extensions/OmhMarkerExtensionsTest.kt
+++ b/packages/plugin-mapbox/src/test/java/com/openmobilehub/android/maps/plugin/mapbox/extensions/OmhMarkerExtensionsTest.kt
@@ -354,8 +354,8 @@ internal class OmhMarkerExtensionsTest(
         verify {
             markerIconLayer.iconIgnorePlacement(true) // defaults from OmhMarkerExtensions
             markerIconLayer.iconAllowOverlap(true) // defaults from OmhMarkerExtensions
-            markerIconLayer.iconImage(previousMarkerIconId!!)
-            markerIconLayer.iconImage(omhMarker.lastMarkerIconID!!)
+            previousMarkerIconId?.let { markerIconLayer.iconImage(it) }
+            omhMarker.lastMarkerIconID?.let { markerIconLayer.iconImage(it) }
             markerIconLayer.iconOpacity(data.alpha.toDouble())
             markerIconLayer.iconPitchAlignment(
                 OmhMarkerImpl.getIconsPitchAlignment(data.isFlat)
@@ -378,22 +378,29 @@ internal class OmhMarkerExtensionsTest(
         every { safeStyle.addSource(capture(capturedSource)) } answers {}
         every { safeStyle.addLayer(capture(capturedLayer)) } answers {}
 
-        verify {
-            // ensure that the previous icon (from the in-between scenario) has been
-            // deleted from the layer to free allocated memory
-            safeStyle.removeStyleImage(previousMarkerIconId!!)
-            // ensure that the previous icon has once been added to the layer
-            safeStyle.addImage(
-                previousMarkerIconId,
-                convertDrawableToBitmapMock,
-                data.icon === null // ensure SDF coloring is only enabled for the default icon
-            )
-            // ensure that the new icon has been added to the layer
-            safeStyle.addImage(
-                omhMarker.lastMarkerIconID!!,
-                convertDrawableToBitmapMock,
-                false // ensure SDF coloring is only enabled for the default icon
-            )
+        if (previousMarkerIconId != null) {
+            verify {
+                // ensure that the previous icon (from the in-between scenario) has been
+                // deleted from the layer to free allocated memory
+                safeStyle.removeStyleImage(previousMarkerIconId)
+                // ensure that the previous icon has once been added to the layer
+                safeStyle.addImage(
+                    previousMarkerIconId,
+                    convertDrawableToBitmapMock,
+                    data.icon === null // ensure SDF coloring is only enabled for the default icon
+                )
+            }
+        }
+
+        omhMarker.lastMarkerIconID?.let {
+            verify {
+                // ensure that the new icon has been added to the layer
+                safeStyle.addImage(
+                    it,
+                    convertDrawableToBitmapMock,
+                    false // ensure SDF coloring is only enabled for the default icon
+                )
+            }
         }
     }
 
@@ -499,7 +506,7 @@ internal class OmhMarkerExtensionsTest(
 
         // here we check if IW properties are valid & set properly on the layer after map style is loaded
         verify {
-            infoWindowLayer.iconImage(omhMarker.omhInfoWindow.lastInfoWindowIconID!!)
+            omhMarker.omhInfoWindow.lastInfoWindowIconID?.let { infoWindowLayer.iconImage(it) }
             infoWindowLayer.iconSize(1.0)
             infoWindowLayer.iconImage(any<String>())
             infoWindowLayer.iconAnchor(IconAnchor.CENTER)

--- a/packages/plugin-mapbox/src/test/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/OmhMarkerImplTest.kt
+++ b/packages/plugin-mapbox/src/test/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/OmhMarkerImplTest.kt
@@ -360,7 +360,7 @@ class OmhMarkerImplTest {
             // marker cleanup
             style.removeStyleLayer(OmhMarkerImpl.getSymbolLayerID(markerUUID))
             style.removeStyleSource(OmhMarkerImpl.getGeoJsonSourceID(markerUUID))
-            style.removeStyleImage(omhMarker.lastMarkerIconID!!)
+            omhMarker.lastMarkerIconID?.let { style.removeStyleImage(it) }
 
             // IW cleanup
             style.removeStyleLayer(omhMarker.omhInfoWindow.getSymbolLayerID())

--- a/packages/plugin-mapbox/src/test/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/OmhMarkerImplTest.kt
+++ b/packages/plugin-mapbox/src/test/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/OmhMarkerImplTest.kt
@@ -360,7 +360,7 @@ class OmhMarkerImplTest {
             // marker cleanup
             style.removeStyleLayer(OmhMarkerImpl.getSymbolLayerID(markerUUID))
             style.removeStyleSource(OmhMarkerImpl.getGeoJsonSourceID(markerUUID))
-            style.removeStyleImage(omhMarker.getMarkerIconID(omhMarker.isCustomIconSet))
+            style.removeStyleImage(omhMarker.lastMarkerIconID!!)
 
             // IW cleanup
             style.removeStyleLayer(omhMarker.omhInfoWindow.getSymbolLayerID())

--- a/packages/plugin-openstreetmap/src/main/java/com/openmobilehub/android/maps/plugin/openstreetmap/presentation/maps/OmhMarkerImpl.kt
+++ b/packages/plugin-openstreetmap/src/main/java/com/openmobilehub/android/maps/plugin/openstreetmap/presentation/maps/OmhMarkerImpl.kt
@@ -16,9 +16,11 @@
 
 package com.openmobilehub.android.maps.plugin.openstreetmap.presentation.maps
 
+import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import com.openmobilehub.android.maps.core.presentation.interfaces.maps.OmhMarker
 import com.openmobilehub.android.maps.core.presentation.models.OmhCoordinate
+import com.openmobilehub.android.maps.core.utils.DrawableConverter
 import com.openmobilehub.android.maps.core.utils.logging.UnsupportedFeatureLogger
 import com.openmobilehub.android.maps.plugin.openstreetmap.extensions.toGeoPoint
 import com.openmobilehub.android.maps.plugin.openstreetmap.extensions.toOmhCoordinate
@@ -115,7 +117,10 @@ internal class OmhMarkerImpl(
     }
 
     override fun setIcon(icon: Drawable?) {
-        marker.icon = icon
+        val bitmap = icon?.let { DrawableConverter.convertDrawableToBitmap(it) }
+        val bitmapAsDrawable = bitmap?.let { BitmapDrawable(mapView.resources, bitmap) }
+
+        marker.icon = bitmapAsDrawable
         marker.updateInfoWindowState() // apply the possibly new marker icon
         mapView.postInvalidate()
     }


### PR DESCRIPTION
## Summary

This PR introduces a few smaller fixes:
- fixes marker icon not changing in specific scenarios:
  - in Azuremaps provider when a marker's icon is changed from a custom-coloured one to the default
  - in Mapbox provider when a marker's icon is changed from a custom icon to another custom icon
  - in Mapbox provider when a marker's icon is changed from a custom-coloured one to the default
- adjusts the OSM provider to work with the new drawable loading system introduced in #88 

## Demo

N/A

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests
