### PR TITLE
feat: added contentDescription attributes to 'center on my location' map button in Mapbox & Azuremaps

### DIFF
--- a/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/MyLocationControl.kt
+++ b/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/MyLocationControl.kt
@@ -27,6 +27,7 @@ class MyLocationControl(context: Context) :
     androidx.appcompat.widget.AppCompatImageButton(context) {
 
     init {
+        contentDescription = context.getString(R.string.button_center_my_location)
         setImageResource(R.drawable.recenter_camera_icon)
         setBackgroundColor(Color.WHITE)
 
@@ -44,6 +45,7 @@ class MyLocationControl(context: Context) :
 
         this.layoutParams = layoutParams
     }
+
     companion object {
         const val BUTTON_SIZE = 44.0f
         const val BUTTON_TOP_MARGIN = 2.0f

--- a/packages/plugin-azuremaps/src/main/res/values/strings.xml
+++ b/packages/plugin-azuremaps/src/main/res/values/strings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2023 Open Mobile Hub
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <string name="button_center_my_location">Center on my location</string>
+</resources>

--- a/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/OmhMapImpl.kt
+++ b/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/presentation/maps/OmhMapImpl.kt
@@ -63,6 +63,7 @@ import com.openmobilehub.android.maps.core.presentation.models.OmhPolylineOption
 import com.openmobilehub.android.maps.core.utils.ScreenUnitConverter
 import com.openmobilehub.android.maps.core.utils.cartesian.BoundingBox2D
 import com.openmobilehub.android.maps.core.utils.logging.Logger
+import com.openmobilehub.android.maps.plugin.mapbox.R
 import com.openmobilehub.android.maps.plugin.mapbox.extensions.toPoint2D
 import com.openmobilehub.android.maps.plugin.mapbox.presentation.interfaces.IMapDragManagerDelegate
 import com.openmobilehub.android.maps.plugin.mapbox.presentation.interfaces.IOmhInfoWindowMapViewDelegate
@@ -456,6 +457,8 @@ class OmhMapImpl(
         mapView.compass.position = Gravity.TOP or Gravity.START
 
         mapView.scalebar.enabled = false
+
+        myLocationIcon.contentDescription = context.getString(R.string.button_center_my_location)
     }
 
     private fun updateMyLocationIconClickListener() {

--- a/packages/plugin-mapbox/src/main/res/values/strings.xml
+++ b/packages/plugin-mapbox/src/main/res/values/strings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2023 Open Mobile Hub
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <string name="button_center_my_location">Center on my location</string>
+</resources>


### PR DESCRIPTION
## Summary

This PR introduces `contentDescription` attributes to our implementations of the 'center on my location' button for Mapbox & Azuremaps providers, for both a11y and E2E testing purposes. For Googlemaps and OpenStreetMap, the default implementations already provide such attributes.

## Demo

N/A

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests
