### PR TITLE
OMHD-281: Triangle hole borders are broken

### DIFF
--- a/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/utils/Constants.kt
+++ b/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/utils/Constants.kt
@@ -68,7 +68,7 @@ internal object Constants {
      * Large limits prevents converting line joins to bevel joins for sharp angles.
      *  It's required to have parity with Google Maps
      */
-    const val LINE_JOIN_MITER_LIMIT = 700.0
+    const val LINE_JOIN_MITER_LIMIT = 4.0
     const val LINE_JOINT_ROUND_LIMIT = 0.0
 
     // Map Elements

--- a/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/utils/Constants.kt
+++ b/packages/plugin-mapbox/src/main/java/com/openmobilehub/android/maps/plugin/mapbox/utils/Constants.kt
@@ -68,7 +68,7 @@ internal object Constants {
      * Large limits prevents converting line joins to bevel joins for sharp angles.
      *  It's required to have parity with Google Maps
      */
-    const val LINE_JOIN_MITER_LIMIT = 1000.0
+    const val LINE_JOIN_MITER_LIMIT = 700.0
     const val LINE_JOINT_ROUND_LIMIT = 0.0
 
     // Map Elements


### PR DESCRIPTION
## Summary
Via trial and error I found value 4.0 to be the maximum value for the miter limit that do not cause rendering artifacts.

## Demo
Before:
https://github.com/openmobilehub/android-omh-maps/assets/28648651/31ceb536-2a1f-4fd2-b9f7-37cc363fb46b


After:
https://github.com/openmobilehub/android-omh-maps/assets/28648651/a8ff3419-4679-4099-a95e-c70e05da7959

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-{ticket_id}](https://callstackio.atlassian.net/browse/OMHD-{ticket_id})
