### PR TITLE
fix: expose AzureMaps provider's OmhMapImpl for plugin escape hatch

### DIFF
--- a/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMapImpl.kt
+++ b/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMapImpl.kt
@@ -61,7 +61,7 @@ import com.openmobilehub.android.maps.plugin.azuremaps.utils.Constants
 import com.openmobilehub.android.maps.plugin.azuremaps.utils.mapLogger
 
 @SuppressWarnings("TooManyFunctions", "UnusedPrivateMember", "LongParameterList")
-internal class OmhMapImpl(
+class OmhMapImpl(
     private val context: Context,
     private val mapControl: MapControl,
     override val mapView: AzureMap,


### PR DESCRIPTION
## Summary

This PR introduces a fix to AzureMaps provider’s `OmhMapImpl` which declares the class as `internal` and thus effectively prohibits it from being exposed for the use of the plugin escape hatch feature.

## Demo

N/A

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests
