### PR TITLE
feat: update omhmapimpl for azure maps

### DIFF
--- a/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMapImpl.kt
+++ b/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMapImpl.kt
@@ -57,6 +57,7 @@ import com.openmobilehub.android.maps.plugin.azuremaps.presentation.maps.manager
 import com.openmobilehub.android.maps.plugin.azuremaps.presentation.maps.managers.MyLocationManager
 import com.openmobilehub.android.maps.plugin.azuremaps.presentation.maps.managers.PolygonManager
 import com.openmobilehub.android.maps.plugin.azuremaps.presentation.maps.managers.PolylineManager
+import com.openmobilehub.android.maps.plugin.azuremaps.presentation.model.OmhMapView
 import com.openmobilehub.android.maps.plugin.azuremaps.utils.Constants
 import com.openmobilehub.android.maps.plugin.azuremaps.utils.mapLogger
 
@@ -75,8 +76,8 @@ class OmhMapImpl(
     bRunningInTest: Boolean = false
 ) : OmhMap {
 
-    override val mapView: Any
-        get() = Pair(mapControl, azureMap)
+    override val mapView: OmhMapView
+        get() = OmhMapView(azureMap, mapControl)
 
     private val azureMapInterface = object : AzureMapInterface {
         override val sources: SourceManager

--- a/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMapImpl.kt
+++ b/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/maps/OmhMapImpl.kt
@@ -64,26 +64,29 @@ import com.openmobilehub.android.maps.plugin.azuremaps.utils.mapLogger
 class OmhMapImpl(
     private val context: Context,
     private val mapControl: MapControl,
-    override val mapView: AzureMap,
-    private val cameraManager: CameraManager = CameraManager(mapView),
+    private val azureMap: AzureMap,
+    private val cameraManager: CameraManager = CameraManager(azureMap),
     private val myLocationManager: MyLocationManager = MyLocationManager(
         context,
         mapControl,
-        mapView
+        azureMap
     ),
     private val logger: UnsupportedFeatureLogger = mapLogger,
     bRunningInTest: Boolean = false
 ) : OmhMap {
 
+    override val mapView: Any
+        get() = Pair(mapControl, azureMap)
+
     private val azureMapInterface = object : AzureMapInterface {
         override val sources: SourceManager
-            get() = mapView.sources
+            get() = azureMap.sources
         override val layers: LayerManager
-            get() = mapView.layers
+            get() = azureMap.layers
         override val images: ImageManager
-            get() = mapView.images
+            get() = azureMap.images
         override val popups: PopupManager
-            get() = mapView.popups
+            get() = azureMap.popups
     }
     private val mapMarkerManager = MapMarkerManager(context, azureMapInterface)
 
@@ -110,7 +113,7 @@ class OmhMapImpl(
     }
 
     private fun setupTouchInteractionListeners() {
-        mapView.events.add(object : OnFeatureClick {
+        azureMap.events.add(object : OnFeatureClick {
             override fun onFeatureClick(features: MutableList<Feature>?): Boolean {
                 for (feature in features ?: listOf()) {
                     if (featureHandleClick(feature)) {

--- a/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/model/OmhMapView.kt
+++ b/packages/plugin-azuremaps/src/main/java/com/openmobilehub/android/maps/plugin/azuremaps/presentation/model/OmhMapView.kt
@@ -1,0 +1,6 @@
+package com.openmobilehub.android.maps.plugin.azuremaps.presentation.model
+
+import com.azure.android.maps.control.AzureMap
+import com.azure.android.maps.control.MapControl
+
+data class OmhMapView(val azureMap: AzureMap, val mapControl: MapControl)


### PR DESCRIPTION
## Summary

This change is required to fix the location service bug (https://callstackio.atlassian.net/browse/OMHD-314) in RN.
It extends mapView property from `AzureMap` only to pair of `MapControl` and `AzureMaps` to get full access to underlying apis.

## Demo

N/A

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests