### PR TITLE
fix: docs parity matrices - fixed table styling in OSM docs, added missing addMarker contents in Mapbox docs

### DIFF
--- a/packages/plugin-mapbox/README.md
+++ b/packages/plugin-mapbox/README.md
@@ -42,7 +42,7 @@ This plugin provides support for Mapbox by utilizing the [Mapbox Android SDK](ht
 
 | Method                                  | Supported? |
 | --------------------------------------- | :--------: |
-| addMarker                               |     ?      |
+| addMarker                               |     ✅     |
 | addPolyline                             |     ✅     |
 | addPolygon                              |     ✅     |
 | getCameraPositionCoordinate             |     ✅     |

--- a/packages/plugin-openstreetmap/README.md
+++ b/packages/plugin-openstreetmap/README.md
@@ -185,8 +185,8 @@ Comments for partially supported 🟨 properties:
 | remove       |     ✅     |
 
 | Property | Comments                                                                |
-| -------- | ----------------------------------------------------------------------- | --- |
-| setCap   | It applies not only to start and end cap, but to polyline joins as well |     |
+| -------- | ----------------------------------------------------------------------- |
+| setCap   | It applies not only to start and end cap, but to polyline joins as well |
 
 ### Polygon
 


### PR DESCRIPTION
## Summary

This PR adds two minor fixes:
- adds a missing tick mark to `addMarker` parity matrix column in Mapbox docs
- deletes a redundant column in OSM docs parity matrix comments table

## Demo

N/A

## Checklist:

- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests
